### PR TITLE
Removed warnings on socket errors and ClientImpl::getLine()

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -174,7 +174,7 @@ class ClientImpl implements IClient
 			throw new ClientException('Error connecting to ami: ' . $errstr);
 		}
 	    $msg = new LoginAction($this->_user, $this->_pass);
-	    $id = $this->getLine();
+	    $id = @stream_get_line($this->_socket, 1024, Message::EOL);
 	    if (strstr($id, 'Asterisk') === false) {
 	        throw new ClientException('Unknown peer. Is this an ami?: ' . $id);
 	    }
@@ -220,15 +220,6 @@ class ClientImpl implements IClient
 	    if (isset($this->_eventListeners[$id])) {
 	        unset($this->_eventListeners[$id]);
 	    }
-	}
-	/**
-	 * Reads a line over the stream until EOL.
-	 *
-	 * @return string
-	 */
-	protected function getLine()
-	{
-        return @stream_get_line($this->_socket, 1024, Message::EOL);
 	}
 
 	/**


### PR DESCRIPTION
Hi Marcelo,

Would you please pull these changes?

Removed the warnings, because:
1. You already _will_ know something went wrong (because of the Exception)
2. If you catch the exception and do something with it, the warning just becomes unnecessary noise in the error log or on STDOUT.
3. In other places, they were already ignored.

Also, I've removed the ClientImpl::getLine() function, because it is used only once. For the reasoning, see the following quote from the commit message:

>    Even though a possible argument for keeping it may be that it abstracts
>     away getting a single line, I don't think that is a really strong
>     argument.
> 
>    Because this function is only used once, and in a function that directly
>     uses socket functions itself already, this makes the code more complex
>     than needed.

Of course, I can revert that commit, and send it as a different pull request, if needed.

Thanks!
