### PR TITLE
Parse channel variables received as part of Asterisk events.

### DIFF
--- a/src/mg/PAMI/Message/IncomingMessage.php
+++ b/src/mg/PAMI/Message/IncomingMessage.php
@@ -93,11 +93,18 @@ abstract class IncomingMessage extends Message
         $this->rawContent = $rawContent;
         $lines = explode(Message::EOL, $rawContent);
         foreach ($lines as $line) {
-            $content = explode(':', $line);
-            $name = strtolower(trim($content[0]));
-            unset($content[0]);
-            $value = isset($content[1]) ? trim(implode(':', $content)) : '';
-            $this->setKey($name, $value);
+            if (preg_match('/ChanVariable\((.*)\): (.*)=(.*)/', $line, $matches)) {
+                $channel = $matches[1];
+                $name    = trim($matches[2]);
+                $value   = trim($matches[3]);
+                $this->setChannelVariable($channel, $name, $value);
+            } else {
+                $content = explode(':', $line);
+                $name = strtolower(trim($content[0]));
+                unset($content[0]);
+                $value = isset($content[1]) ? trim(implode(':', $content)) : '';
+                $this->setKey($name, $value);
+            }
         }
     }
 }


### PR DESCRIPTION
Asterisk provides the ability to include channel variables in events
sent via AMI.  This is done via channelvars in manager.conf  This commit
adds a channel_variables property to Message with getter and setter. It
also provides an update to the IncomingMessage constructor to detect
channel variable data.
