### PR TITLE
Allow eventListener predicate to be any callable, not just closure

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -318,7 +318,7 @@ class ClientImpl implements IClient
         foreach ($this->_eventListeners as $data) {
             $listener = $data[0];
             $predicate = $data[1];
-            if ($predicate !== null && !$predicate($message)) {
+            if (is_callable($predicate) && !call_user_func($predicate, $message)) {
                 continue;
             }
             if ($listener instanceof \Closure) {


### PR DESCRIPTION
Before this change, the predicate parameter passed in to ClientImpl::registerEventListener had to be a closure/anonymous function because of how it was consumed in ClientImpl::dispatch. This change modifies the dispatch method to consume the predicate in a way that allows any callable to be used as the predicate.
