### PR TITLE
verifies $response type

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -282,7 +282,11 @@ class ClientImpl implements IClient
                 $bMsg .= 'ActionId: ' . $this->_lastActionId . "\r\n" . $aMsg;
                 $event = $this->_messageToEvent($bMsg);
                 $response = $this->findResponse($event);
-                $response->addEvent($event);
+                if ($response === false) {
+                    $this->dispatch($event);
+                } else {
+                    $response->addEvent($event);
+                }
     	    }
     	    if ($this->_logger->isDebugEnabled()) {
        	        $this->_logger->debug('----------------');


### PR DESCRIPTION
ensures that response from ClientImpl::findResponse() is PAMI\Message\Response or false before calling PAMI\Message\Response::addEvent()