### PR TITLE
Added Response factory

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -359,7 +359,15 @@ class ClientImpl implements IClient
 	private function _messageToResponse($msg)
 	{
         //$response = new ResponseMessage($msg);
-		$response = $this->_responseFactory->createFromRaw($this->_logger, $msg, $this->_lastActionClass, $this->_lastResponseHandler);
+		try {
+			$response = $this->_responseFactory->createFromRaw($this->_logger, $msg, $this->_lastActionClass, $this->_lastResponseHandler);
+        } catch (PAMIException $e) {
+			if ($this->_logger->isDebugEnabled()) {
+				$this->_logger->debug(
+					'------ ResponseException: ------ ' . "\n" . $e . '----------'
+				);
+			}
+        }
 	    $actionId = $response->getActionId();
 	    if ($actionId === null) {
 	        $actionId = $this->_lastActionId;
@@ -377,7 +385,17 @@ class ClientImpl implements IClient
 	 */
 	private function _messageToEvent($msg)
 	{
-        return $this->_eventFactory->createFromRaw($msg);
+		$event;
+		try {
+			$event = $this->_eventFactory->createFromRaw($msg);
+        } catch (PAMIException $e) {
+			if ($this->_logger->isDebugEnabled()) {
+				$this->_logger->debug(
+					'------ EventException: ------ ' . "\n" . $e . '----------'
+				);
+			}
+        }
+        return $event;
 	}
 
 	/**

--- a/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -33,6 +33,7 @@ namespace PAMI\Message\Event\Factory\Impl;
 use PAMI\Message\Event\EventMessage;
 use PAMI\Message\Event\UnknownEvent;
 use PAMI\Message\Message;
+use PAMI\Exception\PAMIException;
 
 /**
  * This factory knows which event to return according to a given raw message
@@ -70,10 +71,18 @@ class EventFactoryImpl
         }
         $name = substr($message, $eventStart, $eventEnd - $eventStart);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
-        if (class_exists($className, true)) {
-            return new $className($message);
-        }
-	    return new UnknownEvent($message);
+		if (class_exists($className, true)) {
+			try {
+				return new $className($message);
+			} catch (PAMIException $e) {
+				throw $e;
+			}
+		}
+		try {
+			return new UnknownEvent($message);
+		} catch (PAMIException $e) {
+			throw $e;
+		}
     }
 
     /**

--- a/src/mg/PAMI/Message/IncomingMessage.php
+++ b/src/mg/PAMI/Message/IncomingMessage.php
@@ -97,7 +97,7 @@ abstract class IncomingMessage extends Message
             $name = strtolower(trim($content[0]));
             unset($content[0]);
             $value = isset($content[1]) ? trim(implode(':', $content)) : '';
-            $this->setKey($name, $value);
+            $this->setSanitizedKey($name, $value);
         }
     }
 }

--- a/src/mg/PAMI/Message/IncomingMessage.php
+++ b/src/mg/PAMI/Message/IncomingMessage.php
@@ -28,6 +28,7 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
 /**
  * A generic incoming message.
  *
@@ -97,7 +98,11 @@ abstract class IncomingMessage extends Message
             $name = strtolower(trim($content[0]));
             unset($content[0]);
             $value = isset($content[1]) ? trim(implode(':', $content)) : '';
-            $this->setSanitizedKey($name, $value);
+			try {
+				$this->setSanitizedKey($name, $value);
+			} catch (PAMIException $e) {
+				throw new PAMIException("Error: '" . $e . "'\n Dump RawContent:\n"  . $this->rawContent ."\n");
+			}
         }
     }
 }

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -153,6 +153,8 @@ abstract class Message
 				return (boolean)$value;
 			} else if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
 				return (string)$value;
+			} else if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
+				return (string)htmlspecialchars($value, ENT_QUOTES);
 			} else {
 				throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
 			}

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -130,7 +130,7 @@ abstract class Message
 	}
 
 	/**
-	 * Sanitinze incoming value
+	 * Sanitize incoming value
 	 *
 	 * @param string $value Key value.
 	 *
@@ -154,7 +154,7 @@ abstract class Message
 			} else if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
 				return (string)$value;
 			} else {
-				throw new PAMIException("Incoming String is not clean. Skipping: '" . $value . "'\n");
+				throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
 			}
 		} else if (is_resource($value)) {
 			// failure ?

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -154,7 +154,7 @@ abstract class Message
 			} else if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
 				return (string)$value;
 			} else {
-				throw new PAMIException("Incoming String is not clean. Skipping: '" . $value . "' for key: '" .$key . "'");
+				throw new PAMIException("Incoming String is not clean. Skipping: '" . $value . "'\n");
 			}
 		} else if (is_resource($value)) {
 			// failure ?
@@ -163,7 +163,7 @@ abstract class Message
 			// failure ?
 			return (object)$value;
 		} else {
-			throw new PAMIException("Don't know how to convert: " . $value . " for key: " .$key);
+			throw new PAMIException("Don't know how to convert: '" . $value . "'\n");
 		}
 	}
 

--- a/src/mg/PAMI/Message/OutgoingMessage.php
+++ b/src/mg/PAMI/Message/OutgoingMessage.php
@@ -28,6 +28,8 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
+
 /**
  * A generic outgoing message.
  *
@@ -41,4 +43,44 @@ namespace PAMI\Message;
  */
 abstract class OutgoingMessage extends Message
 {
+	/**
+	 * String of the Class name to handle the Reponse to this Message
+	 * @var string
+	 */
+	private $_responseHandler;
+
+	/**
+	 * Returns '_responseHandler'.
+	 *
+	 * @return string
+	 */
+	public function getResponseHandler()
+	{
+		if (strlen($this->_responseHandler) > 0) {
+			//throw new PAMIException('Hier:' . $this->_responseHandler);
+			return (string)$this->_responseHandler;
+		} else {
+			return "";
+		}
+	}
+
+	/**
+	 * Set '_responseHandler'.
+	 *
+	 * @return void
+	 * @throws if class cannot be found or strlen($responseHandler) == 0
+	 */
+	public function setResponseHandler($responseHandler)
+	{
+		if (0 == strlen($responseHandler)) {
+			throw new PAMIException('ResponseHandler cannot be empty.');
+		}
+
+		$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+		if (class_exists($className, true)) {
+			$this->_responseHandler = $responseHandler;
+		} else {
+			throw new PAMIException('ResponseHandler could not be found.');
+		}
+	}
 }

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -69,10 +69,11 @@ class ResponseFactoryImpl
 				if ($logger->isDebugEnabled()) {
 					$logger->debug('ResponseFactoryImpl::createFromRaw, returning class: ' . $className . "\n");
 				}
-			try {
-				return new $className($message);
-			} catch (PAMIException $e) {
-				throw $e;
+				try {
+					return new $className($message);
+				} catch (PAMIException $e) {
+					throw $e;
+				}
 			}
 		}
 		try {

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This factory knows which response to return according to a given raw message
+ * from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response\Factory\Impl;
+
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Message\Response\GenericResponse;
+use PAMI\Message\Message;
+
+/**
+ * This factory knows which event to return according to a given raw message
+ * from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ResponseFactoryImpl
+{
+    /**
+     * This is our factory method.
+     *
+     * @param string $message Literal message as received from ami.
+     *
+     * @return EventMessage
+     */
+    public static function createFromRaw($logger, $message, $outgoingMessageClass = false, $responseHandler = false)
+    {
+        
+        if ($outgoingMessageClass != false && $responseHandler == false) {
+            $responseHandler = substr($outgoingMessageClass, 20, -6);
+		}
+		if ($responseHandler != false) {
+			$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+			if (class_exists($className, true)) {
+				if ($logger->isDebugEnabled()) {
+					$logger->debug('ResponseFactoryImpl::createFromRaw, returning class: ' . $className . "\n");
+				}
+				return new $className($message);
+			}
+        }
+	    return new GenericResponse($message);
+    }
+
+    /**
+     * Constructor. Nothing to see here, move along.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+}

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -8,12 +8,12 @@
  * @category   Pami
  * @package    Response
  * @subpackage Factory.Impl
- * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @version    SVN: $Id$
  * @link       http://marcelog.github.com/PAMI/
  *
- * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,32 +35,33 @@ use PAMI\Message\Response\GenericResponse;
 use PAMI\Message\Message;
 
 /**
- * This factory knows which event to return according to a given raw message
- * from ami.
+ * This factory knows which reponse handler to return according to a given raw message from ami,
+ * the outgoingMessageClass and responseHandler requested by the Action
  *
  * PHP Version 5
  *
  * @category   Pami
  * @package    Response
  * @subpackage Factory.Impl
- * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
 class ResponseFactoryImpl
 {
-    /**
-     * This is our factory method.
-     *
-     * @param string $message Literal message as received from ami.
-     *
-     * @return EventMessage
-     */
-    public static function createFromRaw($logger, $message, $outgoingMessageClass = false, $responseHandler = false)
-    {
-        
-        if ($outgoingMessageClass != false && $responseHandler == false) {
-            $responseHandler = substr($outgoingMessageClass, 20, -6);
+	/**
+	 * This is our factory method.
+	 *
+	 * @param string $message Literal message as received from ami.
+	 * @param string $outgoingMessageClass ClassName
+	 * @param string $responseHandler
+	 *
+	 * @return EventMessage
+	 */
+	public static function createFromRaw($logger, $message, $outgoingMessageClass = false, $responseHandler = false)
+	{
+		if ($outgoingMessageClass != false && $responseHandler == false) {
+			$responseHandler = substr($outgoingMessageClass, 20, -6);
 		}
 		if ($responseHandler != false) {
 			$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
@@ -70,16 +71,16 @@ class ResponseFactoryImpl
 				}
 				return new $className($message);
 			}
-        }
-	    return new GenericResponse($message);
-    }
+		}
+		return new GenericResponse($message);
+	}
 
-    /**
-     * Constructor. Nothing to see here, move along.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-    }
+	/**
+	 * Constructor. Nothing to see here, move along.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+	}
 }

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -69,10 +69,17 @@ class ResponseFactoryImpl
 				if ($logger->isDebugEnabled()) {
 					$logger->debug('ResponseFactoryImpl::createFromRaw, returning class: ' . $className . "\n");
 				}
+			try {
 				return new $className($message);
+			} catch (PAMIException $e) {
+				throw $e;
 			}
 		}
-		return new GenericResponse($message);
+		try {
+			return new GenericResponse($message);
+		} catch (PAMIException $e) {
+			throw $e;
+		}
 	}
 
 	/**

--- a/src/mg/PAMI/Message/Response/GenericResponse.php
+++ b/src/mg/PAMI/Message/Response/GenericResponse.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+//use PAMI\Message\Message;
+//use PAMI\Message\IncomingMessage;
+//use PAMI\Message\Event\EventMessage;
+use PAMI\Message\Response\ResponseMessage;
+//use PAMI\Exception\PAMIException;
+
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class GenericResponse extends ResponseMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+}

--- a/src/mg/PAMI/Message/Response/ResponseMessage.php
+++ b/src/mg/PAMI/Message/Response/ResponseMessage.php
@@ -32,6 +32,7 @@ namespace PAMI\Message\Response;
 use PAMI\Message\Message;
 use PAMI\Message\IncomingMessage;
 use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
 
 /**
  * A generic response message from ami.
@@ -45,19 +46,19 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ResponseMessage extends IncomingMessage
+abstract class ResponseMessage extends IncomingMessage
 {
     /**
      * Child events.
      * @var EventMessage[]
      */
-    private $_events;
+    protected $_events;
 
     /**
      * Is this response completed? (with all its events).
      * @var boolean
      */
-    private $_completed;
+    protected $_completed;
 
     /**
      * Serialize function.

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -843,7 +843,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
     {
         $now = time();
         $action = new \PAMI\Message\Action\LoginAction('a', 'b');
-        $this->assertEquals($now, $action->getCreatedDate());
+        $this->assertGreaterThanOrEqual($now, $action->getCreatedDate());
         $action->setVariable('variable', 'value');
         $this->assertEquals($action->getVariable('variable'), 'value');
         $this->assertNull($action->getVariable('variable2'));

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -42,866 +42,879 @@ namespace PAMI\Client\Impl {
  */
 class Test_Events extends \PHPUnit_Framework_TestCase
 {
-    private $_properties = array();
+	private $_properties = array();
 
-    public function setUp()
-    {
-        $this->_properties = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
-        );
-    }
-    /**
-     * @test
-     */
-    public function can_report_events()
-    {
-        $eventNames = array(
-            'AsyncAGI', 'AGIExec', 'VarSet', 'Unlink', 'vgsm_sms_rx', 'vgsm_net_state',
-            'vgsm_me_state', 'DTMF', 'Bridge', 'VoicemailUserEntryComplete',
-            'StatusComplete', 'ParkedCallsComplete', 'DBGetResponse',
-            'VoicemailUserEntry', 'Transfer', 'Status', 'ShowDialPlanComplete',
-            'Rename', 'RegistrationsComplete', 'RTPSenderStat', 'RTPReceiverStat',
-            'RTCPSent', 'RTCPReceiverStat', 'RTCPReceived', 'QueueSummaryComplete',
-            'QueueStatusComplete', 'DAHDIShowChannelsComplete', 'QueueSummary',
-            'QueueParams', 'QueueMemberStatus', 'QueueMemberRemoved',
-            'QueueMemberPaused', 'QueueMember', 'QueueMemberAdded', 'PeerlistComplete',
-            'PeerStatus', 'PeerEntry', 'OriginateResponse', 'Newstate', 'Newexten',
-            'Newchannel', 'NewCallerid', 'NewAccountCode', 'MusicOnHold',
-            'MessageWaiting', 'Masquerade', 'ListDialplan', 'Leave', 'Join',
-            'Hold', 'Hangup', 'ExtensionStatus', 'Dial', 'DAHDIShowChannels',
-            'CoreShowChannelsComplete', 'CoreShowChannel', 'ChannelUpdate',
-            'Agents', 'AgentsComplete', 'Agentlogoff', 'Agentlogin', 'AgentConnect',
-            'DongleSMSStatus', 'FullyBooted', 'DongleShowDevicesComplete', 'DongleDeviceEntry',
-            'DongleNewUSSDBase64', 'DongleNewUSSD', 'DongleUSSDStatus', 'DongleNewCUSD',
-            'DongleStatus', 'CEL', 'JabberEvent', 'Registry', 'UserEvent',
-            'ParkedCall', 'UnParkedCall', 'Link'
-        );
-        $eventTranslatedValues = array(
-            'QueueMemberStatus' => array(
-                'Paused' => true
-            ),
-            'QueueMemberPaused' => array(
-                'Paused' => true
-            ),
-            'QueueMember' => array(
-                'Paused' => true
-            ),
-            'QueueMemberAdded' => array(
-                'Paused' => true
-            ),
-        );
-        $eventValues = array(
-            'UserEvent' => array(
-                'Privilege' => 'Privilege',
-                'UniqueID' => 'UniqueID',
-                'UserEvent' => 'UserEvent'
-            ),
-            'Registry' => array(
-                'Channel' => 'Channel',
-                'Domain' => 'Domain',
-                'Status' => 'Status'
-            ),
-            'JabberEvent' => array(
-                'Privilege' => 'Privilege',
-                'Account' => 'Account',
-                'Packet' => 'Packet'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Env',
-                'Channel' => 'Channel',
-                'CommandId' => 'CommandId',
-                'Privilege' => 'Privilege',
-                'SubEvent' => 'SubEvent',
-                'Result' => 'Result'
-            ),
-            'FullyBooted' => array(),
-            'DongleUSSDStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-             ),
-        	'DongleNewUSSDBase64' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-        	'DongleNewCUSD' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleNewUSSD' => array(
-                'Device' => 'Device',
-                'LineCount' => 'LineCount',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleDeviceEntry' => array(
-                'Device' => 'Device',
-                'AudioSetting' => 'AudioSetting',
-                'DataSetting' => 'DataSetting',
-                'IMEISetting' => 'IMEISetting',
-                'IMSISetting' => 'IMSISetting',
-                'ChannelLanguage' => 'ChannelLanguage',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Group' => 'Group',
-                'RXGain' => 'RXGain',
-                'TXGain' => 'TXGain',
-                'U2DIAG' => 'U2DIAG',
-                'UseCallingPres' => 'UseCallingPres',
-                'DefaultCallingPres' => 'DefaultCallingPres',
-                'AutoDeleteSMS' => 'AutoDeleteSMS',
-                'DisableSMS' => 'DisableSMS',
-                'ResetDongle' => 'ResetDongle',
-                'SMSPDU' => 'SMSPDU',
-                'CallWaitingSetting' => 'CallWaitingSetting',
-                'DTMF' => 'DTMF',
-                'MinimalDTMFGap' => 'MinimalDTMFGap',
-                'MinimalDTMFDuration' => 'MinimalDTMFDuration',
-                'MinimalDTMFInterval' => 'MinimalDTMFInterval',
-                'State' => 'State',
-                'AudioState' => 'AudioState',
-                'DataState' => 'DataState',
-                'Voice' => 'Voice',
-                'SMS' => 'SMS',
-                'Manufacturer' => 'Manufacturer',
-                'Model' => 'Model',
-                'Firmware' => 'Firmware',
-                'IMEIState' => 'IMEIState',
-                'IMSIState' => 'IMSIState',
-                'GSMRegistrationStatus' => 'GSMRegistrationStatus',
-                'RSSI' => 'RSSI',
-                'Mode' => 'Mode',
-                'Submode' => 'Submode',
-                'ProviderName' => 'ProviderName',
-                'LocationAreaCode' => 'LocationAreaCode',
-                'CellID' => 'CellID',
-                'SubscriberNumber' => 'SubscriberNumber',
-                'SMSServiceCenter' => 'SMSServiceCenter',
-                'UseUCS2Encoding' => 'UseUCS2Encoding',
-                'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
-                'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
-                'TasksInQueue' => 'TasksInQueue',
-                'CommandsInQueue' => 'CommandsInQueue',
-                'CallWaitingState' => 'CallWaitingState',
-                'CurrentDeviceState' => 'CurrentDeviceState',
-                'DesiredDeviceState' => 'DesiredDeviceState',
-                'CallsChannels' => 'CallsChannels',
-                'Active' => 'Active',
-                'Held' => 'Held',
-                'Dialing' => 'Dialing',
-                'Alerting' => 'Alerting',
-                'Incoming' => 'Incoming',
-                'Waiting' => 'Waiting',
-                'Releasing' => 'Releasing',
-                'Initializing' => 'Initializing'
-        	),
-        	'DongleShowDevicesComplete' => array('ListItems' => 'items'),
-            'DongleSMSStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'DongleStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'AgentConnect' => array(
-                'HoldTime' => 'HoldTime',
-                'Privilege' => 'Privilege',
-                'BridgedChannel' => 'BridgedChannel',
-                'RingTime' => 'RingTime',
-                'Member' => 'Member',
-                'MemberName' => 'MemberName',
-                'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Queue' => 'Queue'
-            ),
-            'Agentlogoff' => array(
-                'Logintime' => 'Logintime',
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-            ),
-            'Agentlogin' => array(
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-            ),
-            'AgentsComplete' => array(),
-            'Agents' => array(
-                'TalkingToChannel' => 'TalkingToChannel',
-                'TalkingTo' => 'TalkingTo',
-                'LoggedInTime' => 'LoggedInTime',
-                'LoggedInChan' => 'LoggedInChan',
-                'Name' => 'Name',
-                'Status' => 'Status',
-                'Agent' => 'Agent'
-            ),
-            'ChannelUpdate' => array(
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'ChannelType' => 'ChannelType',
-        		'UniqueID' => 'UniqueID',
-                'SIPfullcontact' => 'SIPfullcontact',
-                'SIPcallid' => 'SIPcallid'
-            ),
-            'CoreShowChannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'AccountCode' => 'AccountCode',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'CallerIDNum' => 'CallerIDNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Duration' => 'Duration',
-            ),
-            'DAHDIShowChannels' => array(
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Alarm' => 'Alarm',
-                'DND' => 'DND',
-                'SignallingCode' => 'SignallingCode',
-                'Signalling' => 'Signalling'
-            ),
-            'Dial' => array(
-                'Privilege' => 'Privilege',
-                'Destination' => 'Destination',
-                'SubEvent' => 'SubEvent',
-        		'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-        		'DialStatus' => 'DialStatus',
-                'DialString' => 'DialString',
-        		'UniqueID' => 'UniqueID',
-        		'DestUniqueID' => 'DestUniqueID',
-            ),
-            'ExtensionStatus' => array(
-                'Privilege' => 'Privilege',
-                'Status' => 'Status',
-                'Exten' => 'Extension',
-                'Hint' => 'Hint',
-        		'Context' => 'Context',
-            ),
-            'Hangup' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Cause' => 'Cause',
-                'cause-txt' => 'cause-txt'
-            ),
-            'Hold' => array(
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Status' => 'Status',
-                'Channel' => 'Channel',
-            ),
-        	'Join' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-        		'UniqueID' => 'UniqueID',
-                'Position' => 'Position',
-                'Queue' => 'Queue',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'Count' => 'Count',
-            ),
-            'Leave' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Count' => 'Count',
-                'Queue' => 'Queue'
-            ),
-        	'ListDialplan' => array(
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'Registrar' => 'Registrar',
-                'IncludeContext' => 'IncludeContext'
-            ),
-            'Masquerade' => array(
-                'OriginalState' => 'OriginalState',
-                'Original' => 'Original',
-                'CloneState' => 'CloneState',
-                'Clone' => 'Clone',
-                'Privilege' => 'Privilege',
-            ),
-            'MessageWaiting' => array(
-        		'Privilege' => 'Privilege',
-        		'Waiting' => 'Waiting',
-        		'Mailbox' => 'Mailbox',
-            ),
-            'MusicOnHold' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-        		'State' => 'State',
-            ),
-            'NewAccountCode' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'AccountCode' => 'AccountCode',
-                'OldAccountCode' => 'OldAccountCode',
-            ),
-            'NewCallerid' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'CID-CallingPres' => 'CID-CallingPres'
-            ),
-            'Newchannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'AccountCode' => 'AccountCode',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-        	'Newexten' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-        		'UniqueID' => 'UniqueID',
-            ),
-        	'Newstate' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'UniqueID' => 'UniqueID',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName'
-            ),
-            'OriginateResponse' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Response' => 'Response',
-                'ActionID' => 'ActionID',
-                'UniqueID' => 'UniqueID',
-                'Reason' => 'Reason',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-            'PeerEntry' => array(
-                'RealtimeDevice' => 'RealtimeDevice',
-                'Status' => 'Status',
-                'ACL' => 'ACL',
-                'TextSupport' => 'TextSupport',
-                'VideoSupport' => 'VideoSupport',
-                'NatSupport' => 'NatSupport',
-                'Dynamic' => 'Dynamic',
-                'IPPort' => 'IPPort',
-                'IPAddress' => 'IPAddress',
-                'ChanObjectType' => 'ChanObjectType',
-                'ObjectName' => 'ObjectName',
-                'ChannelType' => 'ChannelType',
-            ),
-        	'PeerStatus' => array(
-                'Privilege' => 'Privilege',
-                'ChannelType' => 'ChannelType',
-                'Peer' => 'Peer',
-                'PeerStatus' => 'PeerStatus'
-            ),
-            'QueueMemberRemoved' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberPaused' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege',
-            	'Paused' => 1,
-            ),
-            'QueueMember' => array(
-                'Name' => 'Name',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-            ),
-            'QueueMemberAdded' => array(
-                'MemberName' => 'MemberName',
-                'LastCall' => 'LastCall',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-                'Membership' => 'Membership',
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-        	'QueueParams' => array(
-                'Completed' => '4',
-        		'HoldTime' => '5',
-                'Calls' => '6',
-                'Strategy' => 'Strategy',
-                'Max' => '6',
-                'Queue' => 'Queue',
-                'Weight' => '2',
-                'ServiceLevelPerf' => 'ServiceLevelPerf',
-                'ServiceLevel' => '1',
-                'Abandoned' => '3'
-            ),
-            'QueueSummaryComplete' => array(),
-        	'QueueSummary' => array(
-                'LongestHoldTime' => 'LongestHoldTime',
-                'HoldTime' => 'HoldTime',
-                'Callers' => 'Callers',
-                'Available' => 'Available',
-                'LoggedIn' => 'LoggedIn',
-                'Queue' => 'Queue',
-            ),
-            'QueueStatusComplete' => array(),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'PeerlistComplete' => array('ListItems' => 'ListItems'),
-            'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
-            'RTCPReceived' => array(
-                'DLSR' => 'DLSR',
-                'RTT' => 'RTT',
-                'LastSR' => 'LastSR',
-                'IAJitter' => 'IAJitter',
-                'SequenceNumberCycles' => 'SequenceNumberCycles',
-                'HighestSequence' => 'HighestSequence',
-                'PacketsLost' => 'PacketsLost',
-                'FractionLost' => 'FractionLost',
-                'SenderSSRC' => 'SenderSSRC',
-                'ReceptionReports' => 'ReceptionReports',
-                'PT' => 'PT',
-                'Privilege' => 'Privilege',
-                'From' => 'From',
-            ),
-            'RTCPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'RTCPSent' => array(
-                'DLSR' => 'DLSR',
-                'TheirLastSR' => 'TheirLastSR',
-                'IAJitter' => 'IAJitter',
-                'CumulativeLoss' => 'CumulativeLoss',
-                'FractionLost' => 'FractionLost',
-                'ReportBlock' => 'ReportBlock',
-                'SentOctets' => 'SentOctets',
-                'SentPackets' => 'SentPackets',
-                'SentRTP' => 'SentRTP',
-                'SentNTP' => 'SentNTP',
-                'OurSSRC' => 'OurSSRC',
-                'To' => 'To',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPSenderStat' => array(
-                'SRCount' => 'SRCount',
-                'RTT' => 'RTT',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'SentPackets' => 'SentPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'Rename' => array(
-                'UniqueID' => 'UniqueID',
-                'Oldname' => 'Oldname',
-                'Newname' => 'Newname',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege'
-            ),
-            'ShowDialPlanComplete' => array(
-                'listcontexts' => 'listcontexts',
-                'listpriorities' => 'listpriorities',
-                'listextensions' => 'listextensions',
-                'listitems' => 'listitems',
-                'privilege' => 'privilege'
-            ),
-            'Status' => array(
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Seconds' => 'Seconds',
-                'AccountCode' => 'AccountCode',
-                'Duration' => 'Duration',
-                'CallerIDNum' => 'CallerIDNum',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'UniqueID' => 'UniqueID',
-        		'Privilege' => 'Privilege',
-                'Channel' => 'Channel'
-            ),
-            'Transfer' => array(
-                'TransferContext' => 'TransferContext',
-                'TransferExten' => 'TransferExten',
-                'TargetUniqueid' => 'TargetUniqueid',
-                'UniqueID' => 'UniqueID',
-                'SIP-Callid' => 'SIP-Callid',
-                'TargetChannel' => 'TargetChannel',
-                'Channel' => 'Channel',
-                'TransferType' => 'TransferType',
-                'TransferMethod' => 'TransferMethod',
-                'Privilege' => 'Privilege'
-            ),
-            'VoicemailUserEntryComplete' => array(),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VmContext',
-                'VoicemailBox' => 'VoicemailBox',
-                'Fullname' => 'Fullname',
-                'Email' => 'Email',
-                'Pager' => 'Pager',
-                'ServerEmail' => 'ServerEmail',
-                'MailCommand' => 'MailCommand',
-                'Language' => 'Language',
-                'Timezone' => 'Timezone',
-                'Callback' => 'Callback',
-                'DialOut' => 'DialOut',
-                'UniqueID' => 'UniqueID',
-                'ExitContext' => 'ExitContext',
-                'SayDurationMin' => 'SayDurationMin',
-                'SayEnvelope' => 'SayEnvelope',
-                'SayCID' => 'SayCID',
-                'AttachMessage' => 'AttachMessage',
-                'AttachmentFormat' => 'AttachmentFormat',
-                'DeleteMessage' => 'DeleteMessage',
-                'VolumeGain' => 'VolumeGain',
-                'CanReview' => 'CanReview',
-                'CallOperator' => 'CallOperator',
-                'MaxMessageCount' => 'MaxMessageCount',
-                'MaxMessageLength' => 'MaxMessageLength',
-                'NewMessageCount' => 'NewMessageCount'
-            ),
-            'DBGetResponse' => array(
-                'Family' => 'Family',
-                'Key' => 'Key',
-                'Val' => 'Val'
-            ),
-        	'ParkedCallsComplete' => array(),
-        	'StatusComplete' => array('Items' => 'Items'),
-            'RegistrationsComplete' => array('ListItems' => 'ListItems'),
-            'DTMF' => array(
-            	'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Direction' => 'Direction',
-                'End' => 'End',
-                'Begin' => 'Begin',
-                'Digit' => 'Digit'
-        	),
-            'AGIExec' => array(
-            	'Privilege' => 'Privilege',
-            	'CommandId' => 'CommandId',
-                'SubEvent' => 'SubEvent',
-                'Channel' => 'Channel',
-                'Command' => 'Command',
-                'Result' => 'Result',
-                'ResultCode' => 'ResultCode'
-        	),
-            'VarSet' => array(
-            	'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'Variable' => 'Variable',
-                'Value' => 'Value',
-        	    'UniqueID' => 'UniqueID'
-        	),
-        	'Unlink' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	),
-        	'Bridge' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	    'BridgeState' => 'BridgeStart',
-        	    'BridgeType' => 'BridgeType'
-        	),
-        	'vgsm_sms_rx' => array(
-        		'Privilege' => 'Privilege',
-        		'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
-        	    'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
-        	    'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
-        	    'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
-        	    'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
-        	    'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
-        	    'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
-        	    'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
-        	    'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
-        	    'X-SMS-Message-Type' => 'X-SMS-Message-Type',
-        	    'Content' => 'Content',
-        	    'Date' => 'Date',
-        	    'Content-Transfer-Encoding' => 'ContentEncoding',
-        		'Content-Type' => 'ContentType',
-        	    'MIME-Version' => 'MIME-Version',
-        	    'Subject' => 'Subject',
-        	    'From' => 'From',
-        	    'Received' => 'Received'
-        	),
-        	'vgsm_net_state' => array(
-        		'Privilege' => 'Privilege',
-        		'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
-        	),
-        	'vgsm_me_state' => array(
-        		'Privilege' => 'Privilege',
-        	    'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
-        	    'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
-        	    'X-vGSM-ME-State' => 'X-vGSM-ME-State',
-            ),
-            'CEL' => array(
-                'AMAFlags' => 'AMAFlags',
-                'AccountCode' => 'AccountCode',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'CallerIDani' => 'CallerIDani',
-                'CallerIDdnid' => 'CallerIDdnid',
-                'CallerIDname' => 'CallerIDname',
-                'CallerIDnum' => 'CallerIDnum',
-                'CallerIDrdnis' => 'CallerIDrdnis',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Event' => 'Event',
-                'EventName' => 'EventName',
-                'EventTime' => 'EventTime',
-                'Exten' => 'Exten',
-                'Extra' => 'Extra',
-                'LinkedID' => 'LinkedID',
-                'Peer' => 'Peer',
-                'PeerAccount' => 'PeerAccount',
-                'Privilege' => 'Privilege',
-                'Timestamp' => 'Timestamp',
-                'UniqueID' => 'UniqueID',
-                'Userfield' => 'Userfield',
-            ),
-            'ParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'Timeout' => 'Timeout',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'UnParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'Link' => array(
-                'Privilege' => 'Privilege',
-                'CallerID1' => 'CallerID1',
-                'CallerID2' => 'CallerID2',
-                'UniqueID1' => 'UniqueID1',
-                'UniqueID2' => 'UniqueID2',
-                'Channel1' => 'Channel1',
-                'Channel2' => 'Channel2'
-            ),
-        );
-        $eventGetters = array(
-            'UserEvent' => array(
-                'UserEvent' => 'UserEventName'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Environment'
-            ),
-            'Agents' => array(
-                'LoggedInChan' => 'Channel'
-            ),
-        	'ExtensionStatus' => array(
-                'Exten' => 'Extension'
-            ),
-            'Hangup' => array(
-                'cause-txt' => 'CauseText'
-             ),
-        	'ListDialplan' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'NewCallerid' => array(
-                'CID-CallingPres' => 'CallerIdPres'
-            ),
-            'Newchannel' => array('Exten' => 'Extension'),
-        	'Newexten' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 'Pause'
-            ),
-            'QueueMember' => array(
-                'Name' => 'MemberName'
-            ),
-        	'AGIExec' => array(),
-            'Transfer' => array(
-                'SIP-Callid' => 'SipCallID',
-            ),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VoicemailContext',
-            ),
-            'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
-            'VarSet' => array('Variable' => 'VariableName'),
-        	'StatusComplete' => array('Items' => 'ListItems'),
-            'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
-        	'vgsm_sms_rx' => array(
-        	    'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
-        	    'X-SMS-Reply-Path' => 'ReplyPath',
-        	    'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
-                'X-SMS-SMCC-Number' => 'SMCCNumber',
-        	    'X-SMS-SMCC-TON' => 'SMCCTON',
-        	    'X-SMS-SMCC-NP' => 'SMCCNP',
-        	    'X-SMS-Sender-Number' => 'SenderNumber',
-        	    'X-SMS-Sender-TON' => 'SenderTON',
-        	    'X-SMS-Sender-NP' => 'SenderNP',
-        	    'X-SMS-Message-Type' => 'MessageType',
-                'Content-Transfer-Encoding' => 'ContentEncoding',
-                'Content-Type' => 'ContentType',
-                'MIME-Version' => 'MIMEVersion'
-        	),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
-        	'vgsm_me_state' => array(
-        		'X-vGSM-ME-State-Change-Reason' => 'Reason',
-        	    'X-vGSM-ME-Old-State' => 'OldState',
-        	    'X-vGSM-ME-State' => 'State',
-        	),
-            'ParkedCall' => array('Exten' => 'Extension'),
-            'UnParkedCall' => array('Exten' => 'Extension')
-        );
-        foreach ($eventNames as $eventName) {
-            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
-        }
-    }
+	public function setUp()
+	{
+		$this->_properties = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+		);
+	}
+	/**
+	 * @test
+	 */
+	public function can_report_events()
+	{
+		$eventValues = array(
+			'UserEvent' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'UserEvent' => 'UserEvent'
+			),
+			'Registry' => array(
+				'Channel' => 'Channel',
+				'Domain' => 'Domain',
+				'Status' => 'Status'
+			),
+			'JabberEvent' => array(
+				'Privilege' => 'Privilege',
+				'Account' => 'Account',
+				'Packet' => 'Packet'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Env',
+				'Channel' => 'Channel',
+				'CommandId' => 'CommandId',
+				'Privilege' => 'Privilege',
+				'SubEvent' => 'SubEvent',
+				'Result' => 'Result'
+			),
+			'FullyBooted' => array(),
+			'DongleUSSDStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			 ),
+			'DongleNewUSSDBase64' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewCUSD' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewUSSD' => array(
+				'Device' => 'Device',
+				'LineCount' => 'LineCount',
+				'Privilege' => 'Privilege'
+			),
+			'DongleDeviceEntry' => array(
+				'Device' => 'Device',
+				'AudioSetting' => 'AudioSetting',
+				'DataSetting' => 'DataSetting',
+				'IMEISetting' => 'IMEISetting',
+				'IMSISetting' => 'IMSISetting',
+				'ChannelLanguage' => 'ChannelLanguage',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Group' => 'Group',
+				'RXGain' => 'RXGain',
+				'TXGain' => 'TXGain',
+				'U2DIAG' => 'U2DIAG',
+				'UseCallingPres' => 'UseCallingPres',
+				'DefaultCallingPres' => 'DefaultCallingPres',
+				'AutoDeleteSMS' => 'AutoDeleteSMS',
+				'DisableSMS' => 'DisableSMS',
+				'ResetDongle' => 'ResetDongle',
+				'SMSPDU' => 'SMSPDU',
+				'CallWaitingSetting' => 'CallWaitingSetting',
+				'DTMF' => 'DTMF',
+				'MinimalDTMFGap' => 'MinimalDTMFGap',
+				'MinimalDTMFDuration' => 'MinimalDTMFDuration',
+				'MinimalDTMFInterval' => 'MinimalDTMFInterval',
+				'State' => 'State',
+				'AudioState' => 'AudioState',
+				'DataState' => 'DataState',
+				'Voice' => 'Voice',
+				'SMS' => 'SMS',
+				'Manufacturer' => 'Manufacturer',
+				'Model' => 'Model',
+				'Firmware' => 'Firmware',
+				'IMEIState' => 'IMEIState',
+				'IMSIState' => 'IMSIState',
+				'GSMRegistrationStatus' => 'GSMRegistrationStatus',
+				'RSSI' => 'RSSI',
+				'Mode' => 'Mode',
+				'Submode' => 'Submode',
+				'ProviderName' => 'ProviderName',
+				'LocationAreaCode' => 'LocationAreaCode',
+				'CellID' => 'CellID',
+				'SubscriberNumber' => 'SubscriberNumber',
+				'SMSServiceCenter' => 'SMSServiceCenter',
+				'UseUCS2Encoding' => 'UseUCS2Encoding',
+				'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
+				'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
+				'TasksInQueue' => 'TasksInQueue',
+				'CommandsInQueue' => 'CommandsInQueue',
+				'CallWaitingState' => 'CallWaitingState',
+				'CurrentDeviceState' => 'CurrentDeviceState',
+				'DesiredDeviceState' => 'DesiredDeviceState',
+				'CallsChannels' => 'CallsChannels',
+				'Active' => 'Active',
+				'Held' => 'Held',
+				'Dialing' => 'Dialing',
+				'Alerting' => 'Alerting',
+				'Incoming' => 'Incoming',
+				'Waiting' => 'Waiting',
+				'Releasing' => 'Releasing',
+				'Initializing' => 'Initializing'
+			),
+			'DongleShowDevicesComplete' => array('ListItems' => 'items'),
+			'DongleSMSStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'DongleStatus' => array(
+				'Privilege' => 'Privilege',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'AgentConnect' => array(
+				'HoldTime' => 'HoldTime',
+				'Privilege' => 'Privilege',
+				'BridgedChannel' => 'BridgedChannel',
+				'RingTime' => 'RingTime',
+				'Member' => 'Member',
+				'MemberName' => 'MemberName',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Queue' => 'Queue'
+			),
+			'Agentlogoff' => array(
+				'Logintime' => 'Logintime',
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+			),
+			'Agentlogin' => array(
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+			),
+			'AgentsComplete' => array(),
+			'Agents' => array(
+				'TalkingToChannel' => 'TalkingToChannel',
+				'TalkingTo' => 'TalkingTo',
+				'LoggedInTime' => 'LoggedInTime',
+				'LoggedInChan' => 'LoggedInChan',
+				'Name' => 'Name',
+				'Status' => 'Status',
+				'Agent' => 'Agent'
+			),
+			'ChannelUpdate' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'ChannelType' => 'ChannelType',
+				'UniqueID' => 'UniqueID',
+				'SIPfullcontact' => 'SIPfullcontact',
+				'SIPcallid' => 'SIPcallid'
+			),
+			'CoreShowChannel' => array(
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'AccountCode' => 'AccountCode',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'CallerIDNum' => 'CallerIDNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Duration' => 'Duration',
+			),
+			'DAHDIShowChannels' => array(
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Alarm' => 'Alarm',
+				'DND' => 'DND',
+				'SignallingCode' => 'SignallingCode',
+				'Signalling' => 'Signalling'
+			),
+			'Dial' => array(
+				'Privilege' => 'Privilege',
+				'Destination' => 'Destination',
+				'SubEvent' => 'SubEvent',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'DialStatus' => 'DialStatus',
+				'DialString' => 'DialString',
+				'UniqueID' => 'UniqueID',
+				'DestUniqueID' => 'DestUniqueID',
+			),
+			'ExtensionStatus' => array(
+				'Privilege' => 'Privilege',
+				'Status' => 'Status',
+				'Exten' => 'Extension',
+				'Hint' => 'Hint',
+				'Context' => 'Context',
+			),
+			'Hangup' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Cause' => 'Cause',
+				'cause-txt' => 'cause-txt'
+			),
+			'Hold' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Status' => 'Status',
+				'Channel' => 'Channel',
+			),
+			'Join' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'Position' => 'Position',
+				'Queue' => 'Queue',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'Count' => 'Count',
+			),
+			'Leave' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Count' => 'Count',
+				'Queue' => 'Queue'
+			),
+			'ListDialplan' => array(
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'Registrar' => 'Registrar',
+				'IncludeContext' => 'IncludeContext'
+			),
+			'Masquerade' => array(
+				'OriginalState' => 'OriginalState',
+				'Original' => 'Original',
+				'CloneState' => 'CloneState',
+				'Clone' => 'Clone',
+				'Privilege' => 'Privilege',
+			),
+			'MessageWaiting' => array(
+				'Privilege' => 'Privilege',
+				'Waiting' => 'Waiting',
+				'Mailbox' => 'Mailbox',
+			),
+			'MusicOnHold' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'State' => 'State',
+			),
+			'NewAccountCode' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'AccountCode' => 'AccountCode',
+				'OldAccountCode' => 'OldAccountCode',
+			),
+			'NewCallerid' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'CID-CallingPres' => 'CID-CallingPres'
+			),
+			'Newchannel' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'AccountCode' => 'AccountCode',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'Newexten' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+			),
+			'Newstate' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName'
+			),
+			'OriginateResponse' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Response' => 'Response',
+				'ActionID' => 'ActionID',
+				'UniqueID' => 'UniqueID',
+				'Reason' => 'Reason',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'PeerEntry' => array(
+				'RealtimeDevice' => 'RealtimeDevice',
+				'Status' => 'Status',
+				'ACL' => 'ACL',
+				'TextSupport' => 'TextSupport',
+				'VideoSupport' => 'VideoSupport',
+				'NatSupport' => 'NatSupport',
+				'Dynamic' => 'Dynamic',
+				'IPPort' => 'IPPort',
+				'IPAddress' => 'IPAddress',
+				'ChanObjectType' => 'ChanObjectType',
+				'ObjectName' => 'ObjectName',
+				'ChannelType' => 'ChannelType',
+			),
+			'PeerStatus' => array(
+				'Privilege' => 'Privilege',
+				'ChannelType' => 'ChannelType',
+				'Peer' => 'Peer',
+				'PeerStatus' => 'PeerStatus'
+			),
+			'QueueMemberRemoved' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberPaused' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege',
+				'Paused' => 1,
+			),
+			'QueueMember' => array(
+				'Name' => 'Name',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+			),
+			'QueueMemberAdded' => array(
+				'MemberName' => 'MemberName',
+				'LastCall' => 'LastCall',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueParams' => array(
+				'Completed' => '4',
+				'HoldTime' => '5',
+				'Calls' => '6',
+				'Strategy' => 'Strategy',
+				'Max' => '6',
+				'Queue' => 'Queue',
+				'Weight' => '2',
+				'ServiceLevelPerf' => 'ServiceLevelPerf',
+				'ServiceLevel' => '1',
+				'Abandoned' => '3'
+			),
+			'QueueSummaryComplete' => array(),
+			'QueueSummary' => array(
+				'LongestHoldTime' => 'LongestHoldTime',
+				'HoldTime' => 'HoldTime',
+				'Callers' => 'Callers',
+				'Available' => 'Available',
+				'LoggedIn' => 'LoggedIn',
+				'Queue' => 'Queue',
+			),
+			'QueueStatusComplete' => array(),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'PeerlistComplete' => array('ListItems' => 'ListItems'),
+			'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
+			'RTCPReceived' => array(
+				'DLSR' => 'DLSR',
+				'RTT' => 'RTT',
+				'LastSR' => 'LastSR',
+				'IAJitter' => 'IAJitter',
+				'SequenceNumberCycles' => 'SequenceNumberCycles',
+				'HighestSequence' => 'HighestSequence',
+				'PacketsLost' => 'PacketsLost',
+				'FractionLost' => 'FractionLost',
+				'SenderSSRC' => 'SenderSSRC',
+				'ReceptionReports' => 'ReceptionReports',
+				'PT' => 'PT',
+				'Privilege' => 'Privilege',
+				'From' => 'From',
+			),
+			'RTCPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'RTCPSent' => array(
+				'DLSR' => 'DLSR',
+				'TheirLastSR' => 'TheirLastSR',
+				'IAJitter' => 'IAJitter',
+				'CumulativeLoss' => 'CumulativeLoss',
+				'FractionLost' => 'FractionLost',
+				'ReportBlock' => 'ReportBlock',
+				'SentOctets' => 'SentOctets',
+				'SentPackets' => 'SentPackets',
+				'SentRTP' => 'SentRTP',
+				'SentNTP' => 'SentNTP',
+				'OurSSRC' => 'OurSSRC',
+				'To' => 'To',
+				'Privilege' => 'Privilege'
+			),
+			'RTPSenderStat' => array(
+				'SRCount' => 'SRCount',
+				'RTT' => 'RTT',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'SentPackets' => 'SentPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege'
+			),
+			'RTPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'Rename' => array(
+				'UniqueID' => 'UniqueID',
+				'Oldname' => 'Oldname',
+				'Newname' => 'Newname',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege'
+			),
+			'ShowDialPlanComplete' => array(
+				'listcontexts' => 'listcontexts',
+				'listpriorities' => 'listpriorities',
+				'listextensions' => 'listextensions',
+				'listitems' => 'listitems',
+				'privilege' => 'privilege'
+			),
+			'Status' => array(
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Seconds' => 'Seconds',
+				'AccountCode' => 'AccountCode',
+				'Duration' => 'Duration',
+				'CallerIDNum' => 'CallerIDNum',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel'
+			),
+			'Transfer' => array(
+				'TransferContext' => 'TransferContext',
+				'TransferExten' => 'TransferExten',
+				'TargetUniqueid' => 'TargetUniqueid',
+				'UniqueID' => 'UniqueID',
+				'SIP-Callid' => 'SIP-Callid',
+				'TargetChannel' => 'TargetChannel',
+				'Channel' => 'Channel',
+				'TransferType' => 'TransferType',
+				'TransferMethod' => 'TransferMethod',
+				'Privilege' => 'Privilege'
+			),
+			'VoicemailUserEntryComplete' => array(),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VmContext',
+				'VoicemailBox' => 'VoicemailBox',
+				'Fullname' => 'Fullname',
+				'Email' => 'Email',
+				'Pager' => 'Pager',
+				'ServerEmail' => 'ServerEmail',
+				'MailCommand' => 'MailCommand',
+				'Language' => 'Language',
+				'Timezone' => 'Timezone',
+				'Callback' => 'Callback',
+				'DialOut' => 'DialOut',
+				'UniqueID' => 'UniqueID',
+				'ExitContext' => 'ExitContext',
+				'SayDurationMin' => 'SayDurationMin',
+				'SayEnvelope' => 'SayEnvelope',
+				'SayCID' => 'SayCID',
+				'AttachMessage' => 'AttachMessage',
+				'AttachmentFormat' => 'AttachmentFormat',
+				'DeleteMessage' => 'DeleteMessage',
+				'VolumeGain' => 'VolumeGain',
+				'CanReview' => 'CanReview',
+				'CallOperator' => 'CallOperator',
+				'MaxMessageCount' => 'MaxMessageCount',
+				'MaxMessageLength' => 'MaxMessageLength',
+				'NewMessageCount' => 'NewMessageCount'
+			),
+			'DBGetResponse' => array(
+				'Family' => 'Family',
+				'Key' => 'Key',
+				'Val' => 'Val'
+			),
+			'ParkedCallsComplete' => array(),
+			'StatusComplete' => array('Items' => 'Items'),
+			'RegistrationsComplete' => array('ListItems' => 'ListItems'),
+			'DTMF' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Direction' => 'Direction',
+				'End' => 'End',
+				'Begin' => 'Begin',
+				'Digit' => 'Digit'
+			),
+			'AGIExec' => array(
+				'Privilege' => 'Privilege',
+				'CommandId' => 'CommandId',
+				'SubEvent' => 'SubEvent',
+				'Channel' => 'Channel',
+				'Command' => 'Command',
+				'Result' => 'Result',
+				'ResultCode' => 'ResultCode'
+			),
+			'VarSet' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'Variable' => 'Variable',
+				'Value' => 'Value',
+				'UniqueID' => 'UniqueID'
+			),
+			'Unlink' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+			),
+			'Bridge' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+				'BridgeState' => 'BridgeStart',
+				'BridgeType' => 'BridgeType'
+			),
+			'vgsm_sms_rx' => array(
+				'Privilege' => 'Privilege',
+				'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
+				'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
+				'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
+				'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
+				'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
+				'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
+				'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
+				'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
+				'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
+				'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
+				'X-SMS-Message-Type' => 'X-SMS-Message-Type',
+				'Content' => 'Content',
+				'Date' => 'Date',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIME-Version',
+				'Subject' => 'Subject',
+				'From' => 'From',
+				'Received' => 'Received'
+			),
+			'vgsm_net_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
+			),
+			'vgsm_me_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
+				'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
+				'X-vGSM-ME-State' => 'X-vGSM-ME-State',
+			),
+			'CEL' => array(
+				'AMAFlags' => 'AMAFlags',
+				'AccountCode' => 'AccountCode',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'CallerIDani' => 'CallerIDani',
+				'CallerIDdnid' => 'CallerIDdnid',
+				'CallerIDname' => 'CallerIDname',
+				'CallerIDnum' => 'CallerIDnum',
+				'CallerIDrdnis' => 'CallerIDrdnis',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Event' => 'Event',
+				'EventName' => 'EventName',
+				'EventTime' => 'EventTime',
+				'Exten' => 'Exten',
+				'Extra' => 'Extra',
+				'LinkedID' => 'LinkedID',
+				'Peer' => 'Peer',
+				'PeerAccount' => 'PeerAccount',
+				'Privilege' => 'Privilege',
+				'Timestamp' => 'Timestamp',
+				'UniqueID' => 'UniqueID',
+				'Userfield' => 'Userfield',
+			),
+			'ParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'Timeout' => 'Timeout',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'UnParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'Link' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2'
+			),
+			'SuccessfulAuth' => array(
+				'Privilege' => 'security,all',
+				'EventTV' => '2015-04-04T21:04:12.937+0200',
+				'Severity' => 'Informational',
+				'Service' => 'AMI',
+				'EventVersion' => '1',
+				'AccountID' => 'admin',
+				'SessionID' => '0x7fa9d41418c8',
+				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
+				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
+				'UsingPassword' => '0',
+				'SessionTV' => '2015-04-04T21:04:12.937+0200',
+			),
+			'RequestBadFormat' => array(
+				'Privilege' => 'security,all',
+				'EventTV' => '2015-04-04T21:04:12.937+0200',
+				'Severity' => 'Informational',
+				'Service' => 'AMI',
+				'EventVersion' => '1',
+				'AccountID' => 'admin',
+				'SessionID' => '0x7fa9d41418c8',
+				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
+				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
+				'UsingPassword' => '0',
+				'SessionTV' => '2015-04-04T21:04:12.937+0200',
+			),
+		);
+		$eventTranslatedValues = array(
+			'QueueMemberStatus' => array(
+				'Paused' => true
+			),
+			'QueueMemberPaused' => array(
+				'Paused' => true
+			),
+			'QueueMember' => array(
+				'Paused' => true
+			),
+			'QueueMemberAdded' => array(
+				'Paused' => true
+			),
+			'SuccessfulAuth' => array(
+				'EventVersion' => 1,
+				'UsingPassword' => false,
+			),
+			'RequestBadFormat' => array(
+				'EventVersion' => 1,
+				'UsingPassword' => false,
+			),
+		);
+		$eventGetters = array(
+			'UserEvent' => array(
+				'UserEvent' => 'UserEventName'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Environment'
+			),
+			'Agents' => array(
+				'LoggedInChan' => 'Channel'
+			),
+			'ExtensionStatus' => array(
+				'Exten' => 'Extension'
+			),
+			'Hangup' => array(
+				'cause-txt' => 'CauseText'
+			 ),
+			'ListDialplan' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'NewCallerid' => array(
+				'CID-CallingPres' => 'CallerIdPres'
+			),
+			'Newchannel' => array('Exten' => 'Extension'),
+			'Newexten' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 'Pause'
+			),
+			'QueueMember' => array(
+				'Name' => 'MemberName'
+			),
+			'AGIExec' => array(),
+			'Transfer' => array(
+				'SIP-Callid' => 'SipCallID',
+			),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VoicemailContext',
+			),
+			'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
+			'VarSet' => array('Variable' => 'VariableName'),
+			'StatusComplete' => array('Items' => 'ListItems'),
+			'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
+			'vgsm_sms_rx' => array(
+				'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
+				'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
+				'X-SMS-Reply-Path' => 'ReplyPath',
+				'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
+				'X-SMS-SMCC-Number' => 'SMCCNumber',
+				'X-SMS-SMCC-TON' => 'SMCCTON',
+				'X-SMS-SMCC-NP' => 'SMCCNP',
+				'X-SMS-Sender-Number' => 'SenderNumber',
+				'X-SMS-Sender-TON' => 'SenderTON',
+				'X-SMS-Sender-NP' => 'SenderNP',
+				'X-SMS-Message-Type' => 'MessageType',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIMEVersion'
+			),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
+			'vgsm_me_state' => array(
+				'X-vGSM-ME-State-Change-Reason' => 'Reason',
+				'X-vGSM-ME-Old-State' => 'OldState',
+				'X-vGSM-ME-State' => 'State',
+			),
+			'ParkedCall' => array('Exten' => 'Extension'),
+			'UnParkedCall' => array('Exten' => 'Extension')
+		);
+		foreach (array_keys($eventValues) as $eventName) {
+			$this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+		}
+	}
 
-    private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
-    {
-        global $mock_stream_socket_client;
-        global $mock_stream_set_blocking;
-        global $mockTime;
-        global $standardAMIStart;
-        $eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
-        $mockTime = true;
-        $mock_stream_socket_client = true;
-        $mock_stream_set_blocking = true;
-        $options = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
-        	'host' => '2.3.4.5',
-            'scheme' => 'tcp://',
-        	'port' => 9999,
-        	'username' => 'asd',
-        	'secret' => 'asd',
-            'connect_timeout' => 10,
-        	'read_timeout' => 10
-        );
-        $write = array(
-        	"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
-        );
-        setFgetsMock($standardAMIStart, $write);
-        $client = new \PAMI\Client\Impl\ClientImpl($options);
-        $client->registerEventListener(new SomeListenerClass);
-	    $client->open();
-	    $message = array();
-	    $message[] = 'Event: ' . $eventName;
-	    foreach ($values as $key => $value) {
-	        $message[] = $key . ': ' . $value;
-	    }
-	    $message[] = '';
-	    setFgetsMock($message, $message);
-	    for($i = 0; $i < count($message); $i++) {
-	        $client->process();
-	    }
-	    $event = SomeListenerClass::$event;
-        $this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
-        foreach ($values as $key => $value) {
-            if (isset($getters[$eventName][$key])) {
-                $methodName = 'get' . $getters[$eventName][$key];
-            } else {
-                $methodName = 'get' . $key;
-            }
-            if (isset($translatedValues[$eventName][$key])) {
-                $value = $translatedValues[$eventName][$key];
-            }
-            $this->assertEquals($event->$methodName(), $value);
-        }
-    }
+	private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
+	{
+		global $mock_stream_socket_client;
+		global $mock_stream_set_blocking;
+		global $mockTime;
+		global $standardAMIStart;
+		$eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
+		$mockTime = true;
+		$mock_stream_socket_client = true;
+		$mock_stream_set_blocking = true;
+		$options = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
+			'host' => '2.3.4.5',
+			'scheme' => 'tcp://',
+			'port' => 9999,
+			'username' => 'asd',
+			'secret' => 'asd',
+			'connect_timeout' => 10,
+			'read_timeout' => 10
+		);
+		$write = array(
+			"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
+		);
+		setFgetsMock($standardAMIStart, $write);
+		$client = new \PAMI\Client\Impl\ClientImpl($options);
+		$client->registerEventListener(new SomeListenerClass);
+		$client->open();
+		$message = array();
+		$message[] = 'Event: ' . $eventName;
+		foreach ($values as $key => $value) {
+			$message[] = $key . ': ' . $value;
+		}
+		$message[] = '';
+		setFgetsMock($message, $message);
+		for($i = 0; $i < count($message); $i++) {
+			$client->process();
+		}
+		$event = SomeListenerClass::$event;
+		$this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
+		foreach ($values as $key => $value) {
+			if (isset($getters[$eventName][$key])) {
+				$methodName = 'get' . $getters[$eventName][$key];
+			} else {
+				$methodName = 'get' . $key;
+			}
+			if (isset($translatedValues[$eventName][$key])) {
+				$value = $translatedValues[$eventName][$key];
+			}
+			$this->assertEquals($event->$methodName(), $value, "Event: '$eventName'->'$methodName' to retrieve Key: '$key', returned Value: '". var_dump($event->$methodName()) ."' instead of expected: '" . var_dump($value) . "'");
+		}
+	}
 }
 }


### PR DESCRIPTION
I added a response factory (following the event factory example)

1. Allows you to setResponseHandler("MyDefaultHandler") from MyMessageAction.php
2. Searches for Response with the same name as the Action
/PAMI/Message/Action/TestAction -> /PAMI/Message/Response/TestResponse
3. Falls back to GenericResponse Handler  (Like UnknownEvent)

This will make it easier for people to extend the handling of ResponseMessage.php  without having to change this file. 