### PR TITLE
Added a currently known Actions and Events to deal with chan-sccp-b AMI

### DIFF
--- a/docs/examples/sccp/example.php
+++ b/docs/examples/sccp/example.php
@@ -185,32 +185,30 @@ try
 		} 
 	}
 */
-//	var_dump($a->send(new SCCPShowDeviceAction("SEP0023043403F9")));
-/*	$response = $a->send(new SCCPShowDeviceAction("SEP0023043403F9"));
+	//var_dump($a->send(new SCCPShowDeviceAction("SEP0023043403F9")));
+	$response = $a->send(new SCCPShowDeviceAction("SEP0023043403F9"));
 	if ($response->isList()) {
 		$events = $response->getEvents(); 
-		$mainevent = $events[0];
-		print ("DeviceName" . $mainevent->getDeviceName() . "\n");
+		print ("DeviceName" . $response->getDeviceName() . "\n");
 		print ("\nDenyPermit:\n");
-		print_r ($mainevent->getDenyPermit());
+		print_r ($response->getDenyPermit());
 		print ("\nCaps:\n");
-		print_r ($mainevent->getCapabilities());
+		print_r ($response->getCapabilities());
 		print ("\nPrefs:\n");
-		print_r ($mainevent->getCodecsPreference());
+		print_r ($response->getCodecsPreference());
 	}
 	$tableNames = $response->getTableNames();
 	foreach ($tableNames as $tableName) {
 		print "Table: $tableName\n";
+		$method = 'get' . $tableName;
+		$table = $response->$method();
+		foreach ($table as $entry) {
+			print_r ($entry);
+		} 
 	}
-	$buttontable = $response->getTable('DeviceButtons');
-	print("TableName: " . $buttontable['Name'] . "\n");
-	foreach ($buttontable as $button) {
-		print_r ($button);
-	} 
-*/
-	var_dump($a->send(new SCCPShowLineAction("98011")));
-	var_dump($a->send(new SCCPShowChannelsAction()));
-	var_dump($a->send(new SCCPShowSessionsAction()));
+//	var_dump($a->send(new SCCPShowLineAction("98011")));
+//	var_dump($a->send(new SCCPShowChannelsAction()));
+//	var_dump($a->send(new SCCPShowSessionsAction()));
 
     $time = time();
     while(( time() - $time) < $argv[5]) // Wait for events.

--- a/docs/examples/sccp/example.php
+++ b/docs/examples/sccp/example.php
@@ -1,0 +1,229 @@
+<?php
+declare(ticks=1);
+/**
+ * PAMI basic use example.
+ *
+ * PHP Version 5
+ *
+ * @category Pami
+ * @author   Marcelo Gornstein <marcelog@gmail.com>
+ * @license  http://www.noneyet.ar/ Apache License 2.0
+ * @version  SVN: $Id$
+ * @link     http://www.noneyet.ar/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+if ($argc != 7) {
+    echo "Use: $argv[0] <host> <port> <user> <pass> <connect timeout> <read timeout>";
+    exit (254);
+}
+
+// Setup include path.
+ini_set(
+    'include_path',
+    implode(
+        PATH_SEPARATOR,
+        array(
+            implode(DIRECTORY_SEPARATOR, array('..', '..', '..', 'src', 'mg')),
+            '../../../vendor/php/log4php', '../../../vendor/php',
+            ini_get('include_path'),
+        )
+    )
+);
+
+////////////////////////////////////////////////////////////////////////////////
+// Mandatory stuff to bootstrap.
+////////////////////////////////////////////////////////////////////////////////
+require_once 'PAMI/Autoloader/Autoloader.php'; // Include PAMI autoloader.
+\PAMI\Autoloader\Autoloader::register(); // Call autoloader register for PAMI autoloader.
+use PAMI\Client\Impl\ClientImpl;
+use PAMI\Listener\IEventListener;
+use PAMI\Message\Event\EventMessage;
+use PAMI\Message\Action\GetConfigJSONAction;
+use PAMI\Message\Action\ListCommandsAction;
+use PAMI\Message\Action\SCCPShowDevicesAction;
+use PAMI\Message\Action\SCCPShowGlobalsAction;
+use PAMI\Message\Action\SCCPShowLinesAction;
+use PAMI\Message\Action\SCCPShowDeviceAction;
+use PAMI\Message\Action\SCCPShowLineAction;
+use PAMI\Message\Action\SCCPShowChannelsAction;
+use PAMI\Message\Action\SCCPShowSessionsAction;
+use PAMI\Message\Action\SCCPConfigMetaDataAction;
+use PAMI\Message\Event\SuccessfulAuthEvent;
+use PAMI\Message\Event\SCCPGlobalSettingsEvent;
+use PAMI\Message\Event\TableStart;
+use PAMI\Message\Event\TableEnd;
+use PAMI\Message\Event\SCCPLineEntryEvent;
+use PAMI\Message\Event\SCCPShowDeviceEvent;
+use PAMI\Message\Event\SCCPDeviceEntryEvent;
+use PAMI\Message\Event\SCCPDeviceButtonEntryEvent;
+use PAMI\Message\Event\SCCPDeviceFeatureEntryEvent;
+use PAMI\Message\Event\SCCPDeviceSpeeddialEntryEvent;
+use PAMI\Message\Event\SCCPDeviceLineEntryEvent;
+use PAMI\Message\Event\SCCPShowLinesCompleteEvent;
+use PAMI\Message\Event\SCCPShowLineCompleteEvent;
+use PAMI\Message\Event\SCCPShowGlobalsCompleteEvent;
+use PAMI\Message\Event\SCCPShowDevicesCompleteEvent;
+use PAMI\Message\Event\SCCPShowDeviceCompleteEvent;
+use PAMI\Message\Event\SCCPShowChannelsCompleteEvent;
+use PAMI\Message\Event\SCCPShowSessionsCompleteEvent;
+class A implements IEventListener
+{
+    public function handle(EventMessage $event)
+    {
+        var_dump($event);
+    }
+}
+////////////////////////////////////////////////////////////////////////////////
+// Code STARTS.
+////////////////////////////////////////////////////////////////////////////////
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+try
+{
+	$options = array(
+		'log4php.properties' => realpath(__DIR__) . DIRECTORY_SEPARATOR . 'log4php.properties',
+		'host' => $argv[1],
+		'port' => $argv[2],
+		'username' => $argv[3],
+		'secret' => $argv[4],
+		'connect_timeout' => $argv[5],
+		'read_timeout' => $argv[6],
+		'scheme' => 'tcp://' // try tls://
+	);
+	$a = new ClientImpl($options);
+
+	// Registering a closure
+	//$a->registerEventListener(function ($event) {
+	//
+	//});
+
+	// Register a specific method of an object for event listening
+	//$a->registerEventListener(array($listener, 'handle'));
+	// Register an IEventListener:
+
+	$a->registerEventListener(new A());
+	$a->open();
+
+/*
+	var_dump($a->send(new ListCommandsAction()));
+	var_dump($a->send(new GetConfigJSONAction("sip.conf")));
+
+	$response = $a->send(new GetConfigJSONAction("sip.conf"));
+	var_dump($response->getJSON());
+
+	$response = $a->send(new SCCPConfigMetaDataAction());
+	print_r($response->getJSON());
+
+	$response = $a->send(new SCCPConfigMetaDataAction("general"));
+	print_r($response->getJSON());
+*/
+
+/*	$response = $a->send(new SCCPConfigMetaDataAction("device"));
+	print_r($response->getJSON());
+*/	
+//	var_dump($a->send(new SCCPShowGlobalsAction()));
+/*	$response = $a->send(new SCCPShowGlobalsAction());
+	if ($response->isSuccess()) {
+		print "op\n";
+		print "KeepAlive: " . $response->getKey("KeepAlive") . "\n";
+		print "ConfigFile: " . $response->getKey("ConfigFile") . "\n";
+		print "CodecsPreference: ";
+		print_r ($response->getKey("CodecsPreference"));
+		print "\n";
+		if ($response->isList()) {
+			print "ok\n";
+			$events = $response->getEvents();
+			foreach ($events as $event) {
+				if ($event->getName() == "SCCPGlobalSettings") {
+					print "KeepAlive: " . $event->getKeepAlive() . "\n";
+					print "ConfigFile: " . $event->getConfigFile() . "\n";
+					print "CodecsPreference: ";
+					print_r ($event->getCodecsPreference());
+					print "\n";
+				}
+			}
+		}
+		//print_r($response->getJSON());
+	}
+*/
+//	var_dump($a->send(new SCCPShowDevicesAction()));
+/*
+	$response = $a->send(new SCCPShowDevicesAction());
+	if ($response->isList()) {
+		$events = $response->getEvents();
+		foreach ($events as $event) {
+			if ($event->getName() == "SCCPDeviceEntry") {
+				print_r ($event);
+			}
+		} 
+	}
+*/
+//	var_dump($a->send(new SCCPShowLinesAction()));
+/*
+	$response = $a->send(new SCCPShowLinesAction());
+	if ($response->isList()) {
+		$events = $response->getEvents();
+		foreach ($events as $event) {
+			if ($event->getName() == "SCCPLineEntry") {
+				print_r ($event);
+			}
+		} 
+	}
+*/
+//	var_dump($a->send(new SCCPShowDeviceAction("SEP0023043403F9")));
+/*	$response = $a->send(new SCCPShowDeviceAction("SEP0023043403F9"));
+	if ($response->isList()) {
+		$events = $response->getEvents(); 
+		$mainevent = $events[0];
+		print ("DeviceName" . $mainevent->getDeviceName() . "\n");
+		print ("\nDenyPermit:\n");
+		print_r ($mainevent->getDenyPermit());
+		print ("\nCaps:\n");
+		print_r ($mainevent->getCapabilities());
+		print ("\nPrefs:\n");
+		print_r ($mainevent->getCodecsPreference());
+	}
+	$tableNames = $response->getTableNames();
+	foreach ($tableNames as $tableName) {
+		print "Table: $tableName\n";
+	}
+	$buttontable = $response->getTable('DeviceButtons');
+	print("TableName: " . $buttontable['Name'] . "\n");
+	foreach ($buttontable as $button) {
+		print_r ($button);
+	} 
+*/
+	var_dump($a->send(new SCCPShowLineAction("98011")));
+	var_dump($a->send(new SCCPShowChannelsAction()));
+	var_dump($a->send(new SCCPShowSessionsAction()));
+
+    $time = time();
+    while(( time() - $time) < $argv[5]) // Wait for events.
+    {
+        usleep(1000); // 1ms delay
+        // Since we declare(ticks=1) at the top, the following line is not necessary
+        $a->process();
+    }
+
+	$a->close(); // send logoff and close the connection.
+} catch (Exception $e) {
+	echo $e->getMessage() . "\n";
+}
+////////////////////////////////////////////////////////////////////////////////
+// Code ENDS.
+////////////////////////////////////////////////////////////////////////////////

--- a/docs/examples/sccp/log4php.properties
+++ b/docs/examples/sccp/log4php.properties
@@ -1,0 +1,5 @@
+log4php.appender.default = LoggerAppenderDailyFile
+log4php.appender.default.layout = LoggerLayoutPattern
+log4php.appender.default.layout.ConversionPattern = "%d{ISO8601} [%p] %c: %m%n"
+log4php.appender.default.file = log.log
+log4php.rootLogger = DEBUG, default

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -38,6 +38,7 @@ use PAMI\Message\Action\LogoffAction;
 use PAMI\Message\Response\ResponseMessage;
 use PAMI\Message\Event\EventMessage;
 use PAMI\Message\Event\Factory\Impl\EventFactoryImpl;
+use PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl;
 use PAMI\Listener\IEventListener;
 use PAMI\Client\Exception\ClientException;
 use PAMI\Client\IClient;
@@ -105,6 +106,12 @@ class ClientImpl implements IClient
 	private $_eventFactory;
 
 	/**
+	 * Event factory.
+	 * @var EventFactoryImpl
+	 */
+	private $_responseFactory;
+
+	/**
 	 * R/W timeout, in milliseconds.
 	 * @var integer
 	 */
@@ -153,6 +160,16 @@ class ClientImpl implements IClient
 	 * @var string
 	 */
 	private $_lastActionId;
+
+	/**
+	 * @var string
+	 */
+	private $_lastResponseHandler;
+
+	/**
+	 * @var className
+	 */
+	private $_lastActionClass;
 
 	/**
 	 * Opens a tcp connection to ami.
@@ -253,7 +270,7 @@ class ClientImpl implements IClient
 	 * your own application in order to continue reading events and responses
 	 * from ami. 
 	 */
-	public function process()
+	public function process($outgoingMessageClass=false)
 	{
 	    $msgs = $this->getMessages();
 	    foreach ($msgs as $aMsg) {
@@ -267,6 +284,7 @@ class ClientImpl implements IClient
     	    if (($resPos !== false) && (($resPos < $evePos) || $evePos === false)) {
     	        $response = $this->_messageToResponse($aMsg);
                 $this->_incomingQueue[$response->getActionId()] = $response;
+				// unset($this->_outgoingQueue[$response->getActionId()]); pop
     	    } else if ($evePos !== false) {
     	        $event = $this->_messageToEvent($aMsg);
         	    $response = $this->findResponse($event);
@@ -340,7 +358,16 @@ class ClientImpl implements IClient
 	 */
 	private function _messageToResponse($msg)
 	{
-        $response = new ResponseMessage($msg);
+        //$response = new ResponseMessage($msg);
+		try {
+			$response = $this->_responseFactory->createFromRaw($this->_logger, $msg, $this->_lastActionClass, $this->_lastResponseHandler);
+        } catch (PAMIException $e) {
+			if ($this->_logger->isDebugEnabled()) {
+				$this->_logger->debug(
+					'------ ResponseException: ------ ' . "\n" . $e . '----------'
+				);
+			}
+        }
 	    $actionId = $response->getActionId();
 	    if ($actionId === null) {
 	        $actionId = $this->_lastActionId;
@@ -358,7 +385,17 @@ class ClientImpl implements IClient
 	 */
 	private function _messageToEvent($msg)
 	{
-        return $this->_eventFactory->createFromRaw($msg);
+		$event;
+		try {
+			$event = $this->_eventFactory->createFromRaw($msg);
+        } catch (PAMIException $e) {
+			if ($this->_logger->isDebugEnabled()) {
+				$this->_logger->debug(
+					'------ EventException: ------ ' . "\n" . $e . '----------'
+				);
+			}
+        }
+        return $event;
 	}
 
 	/**
@@ -401,7 +438,12 @@ class ClientImpl implements IClient
 	        	'------ Sending: ------ ' . "\n" . $messageToSend . '----------'
 	        );
         }
-	    $this->_lastActionId = $message->getActionId();
+		// If there are multiple outgoing messages in flight, we might have to add this information to a queue instead
+		//$this->_outgoingQueue[$this->_lastActionId] == array('ResponseHandler' => $message->getResponseHandler()); // push
+		$this->_lastActionId = $message->getActionId();
+		$this->_lastResponseHandler = $message->getResponseHandler();
+		$this->_lastActionClass = get_class($message);
+
 	    if (@fwrite($this->_socket, $messageToSend) < $length) {
     	    throw new ClientException('Could not send message');
 	    }
@@ -456,6 +498,7 @@ class ClientImpl implements IClient
 		$this->_scheme = isset($options['scheme']) ? $options['scheme'] : 'tcp://';
 		$this->_eventListeners = array();
 		$this->_eventFactory = new EventFactoryImpl();
+		$this->_responseFactory = new ResponseFactoryImpl();
 		$this->_incomingQueue = array();
 		$this->_lastActionId = false;
 	}

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -248,21 +248,24 @@ class ClientImpl implements IClient
 	{
 	    $msgs = array();
 	    // Read something.
-	    $read = @fread($this->_socket, 65535);
-	    if ($read === false || @feof($this->_socket)) {
-	        throw new ClientException('Error reading');
-	    }
-	    $this->_currentProcessingMessage .= $read;
-	    // If we have a complete message, then return it. Save the rest for
-	    // later.
-	    while (($marker = strpos($this->_currentProcessingMessage, Message::EOM))) {
-    	    $msg = substr($this->_currentProcessingMessage, 0, $marker);
-    	    $this->_currentProcessingMessage = substr(
-    	        $this->_currentProcessingMessage, $marker + strlen(Message::EOM)
-    	    );
-    	    $msgs[] = $msg;
-	    }
-	    return $msgs;
+		$read = @fread($this->_socket, 8192);
+		if ($read === false || @feof($this->_socket)) {
+			throw new ClientException('Error During Socket Read');
+		}
+		//if (strlen($read) > 0) {
+			// we made progress... reset _readtries
+			//$this->_readretries = true;
+		//}
+		$this->_currentProcessingMessage .= $read;
+		// If we have a complete message, then return it. Save the rest for later.
+		while (($marker = strpos($this->_currentProcessingMessage, Message::EOM))) {
+		   $msg = substr($this->_currentProcessingMessage, 0, $marker);
+		   $this->_currentProcessingMessage = substr(
+			   $this->_currentProcessingMessage, $marker + strlen(Message::EOM)
+		   );
+		   $msgs[] = $msg;
+		}
+		return $msgs;
 	}
 
 	/**
@@ -446,21 +449,26 @@ class ClientImpl implements IClient
 
 	    if (@fwrite($this->_socket, $messageToSend) < $length) {
     	    throw new ClientException('Could not send message');
-	    }
-	    $read = 0;
-	    while($read <= $this->_rTimeout) {
-	        $this->process();
-	        $response = $this->getRelated($message);
-	        if ($response != false) {
-	            $this->_lastActionId = false;
-	            return $response;
-	        }
-	        usleep(1000); // 1ms delay
-	        if ($this->_rTimeout > 0) {
-	            $read++;
-	        }
-	    }
-	    throw new ClientException('Read timeout');
+		}
+		while (1) {
+			if ($this->_logger->isDebugEnabled()) $this->_logger->debug('-Reading/Process: rTimeout:' . $this->_rTimeout . "\n");
+			@stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
+			$this->process();
+			$info = @stream_get_meta_data($this->_socket);
+			if ($this->_logger->isDebugEnabled()) $this->_logger->debug('-stream_get_meta_data returned: [' . print_r($info) . "]\n");
+			if ($info['timed_out'] == false) {
+				if ($this->_logger->isDebugEnabled()) $this->_logger->debug("-process response-\n");
+				$response = $this->getRelated($message);
+				if ($response != false) {
+					$this->_lastActionId = false;
+					return $response;
+				}
+			} else {
+				if ($this->_logger->isDebugEnabled()) $this->_logger->debug("-timedout-\n");
+				break;
+			}
+		}
+		throw new ClientException("Read waittime: " . ($this->_rTimeout) . " exceeded (timeout).\n");
 	}
 
 	/**
@@ -494,7 +502,7 @@ class ClientImpl implements IClient
 		$this->_user = $options['username'];
 		$this->_pass = $options['secret'];
 		$this->_cTimeout = $options['connect_timeout'];
-		$this->_rTimeout = $options['read_timeout'];
+		$this->_rTimeout = isset($options['read_timeout']) ? isset($options['read_timeout']) : 1;
 		$this->_scheme = isset($options['scheme']) ? $options['scheme'] : 'tcp://';
 		$this->_eventListeners = array();
 		$this->_eventFactory = new EventFactoryImpl();

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -252,10 +252,6 @@ class ClientImpl implements IClient
 		if ($read === false || @feof($this->_socket)) {
 			throw new ClientException('Error During Socket Read');
 		}
-		//if (strlen($read) > 0) {
-			// we made progress... reset _readtries
-			//$this->_readretries = true;
-		//}
 		$this->_currentProcessingMessage .= $read;
 		// If we have a complete message, then return it. Save the rest for later.
 		while (($marker = strpos($this->_currentProcessingMessage, Message::EOM))) {
@@ -433,20 +429,16 @@ class ClientImpl implements IClient
     	    throw new ClientException('Could not send message');
 		}
 		while (1) {
-			if ($this->_logger->isDebugEnabled()) $this->_logger->debug('-Reading/Process: rTimeout:' . $this->_rTimeout . "\n");
 			@stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
 			$this->process();
 			$info = @stream_get_meta_data($this->_socket);
-			if ($this->_logger->isDebugEnabled()) $this->_logger->debug('-stream_get_meta_data returned: [' . print_r($info) . "]\n");
 			if ($info['timed_out'] == false) {
-				if ($this->_logger->isDebugEnabled()) $this->_logger->debug("-process response-\n");
 				$response = $this->getRelated($message);
 				if ($response != false) {
 					$this->_lastActionId = false;
 					return $response;
 				}
 			} else {
-				if ($this->_logger->isDebugEnabled()) $this->_logger->debug("-timedout-\n");
 				break;
 			}
 		}

--- a/src/mg/PAMI/Message/Action/SCCPAnswerCallAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPAnswerCallAction.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * SCCPAnswerCall1 action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Answer Call action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPAnswerCallAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $ChannelId ChannelId
+     * @param string $DeviceId DeviceId (Required for SharedLine)
+     *
+     * @return void
+     */
+    public function __construct($ChannelId, $DeviceId)
+    {
+    	// is meant to be SCCPAnswerCall1 not SCCPAnswerCall (for now)
+        parent::__construct('SCCPAnswerCall1');
+        $this->setKey('ChannelId', $ChannelId);
+        $this->setKey('DeviceId', $DeviceId);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPConferenceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPConferenceAction.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * SCCPConference action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use \PAMI\Exception\PAMIException;
+/**
+ * SCCP Conference Control Action
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConferenceAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $ConferenceId Conference Id
+     * @param string $ParticipantId Participant Id
+     * @param string $Command Command, one of ['endconf', 'kick', 'mute', 'invite', 'moderate']
+     *
+     * @return void
+     */
+    public function __construct($ConferenceId, $ParticipantId, $Command)
+    {
+        parent::__construct('SCCPConference');
+        $this->setKey('ConferenceId', $ConferenceId);
+        $this->setKey('ParticipantId', $ParticipantId);
+        if (in_array(strtolower($Command), array('endconf', 'kick', 'mute', 'invite', 'moderate'))) {
+	        $this->setKey('Command', strtolower($Command));
+		} else {
+			throw new PAMIException('State has to be one of \'endconf\', \'kick\', \'mute\', \'invite\', \'moderate\'.');
+		}
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPConfigMetaDataAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPConfigMetaDataAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SCCPConfigMetaData action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfigMetaDataAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct($segment=false)
+    {
+        parent::__construct('SCCPConfigMetaData');
+        if ($segment != false) {
+        	$this->setKey('Segment', $segment);
+        }
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPDeviceAddLineAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPDeviceAddLineAction.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * SCCPDeviceAddLine action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceAddLineAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * @param string $LineName Line Name
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $LineName)
+    {
+        parent::__construct('SCCPDeviceAddLine');
+        
+        $this->setKey('DeviceName', $DeviceName);
+        $this->setKey('LineName', $LineName);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPDeviceRestartAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPDeviceRestartAction.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * SCCPDeviceRestart action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use PAMI\Exception\PAMIException;
+
+/**
+ * Restart SCCP Device Action Message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceRestartAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * @param string $Type on of ['restart', 'full', 'reset']
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $Type="restart")
+    {
+        parent::__construct('SCCPDeviceRestart');
+        
+        $this->setKey('DeviceName', $DeviceName);
+        if (in_array(strtolower($Type), array('restart', 'full', 'reset'))) {
+		    $this->setKey('Type', $Type);
+        } else {
+		    throw new PAMIException('Param2 has to be one of \'restart\', \'full\', \'reset\'.');
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPDeviceSetDNDAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPDeviceSetDNDAction.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * SCCPDeviceSetDND action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use PAMI\Exception\PAMIException;
+
+/**
+ * Set Do Not Disturb on SCCP Device Action Message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceSetDNDAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * @param string $DNDState DND State to put the Device in, has to be one of ['on', 'reject', 'silent', 'off']
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $DNDState)
+    {
+        parent::__construct('SCCPDeviceSetDND');
+        
+        $this->setKey('DeviceName', $DeviceName);
+        if (in_array(strtolower($DNDState), array('on', 'reject', 'silent', 'off'))) {
+	    	$this->setKey('DNDState', $DNDState);
+        } else {
+	    	throw new PAMIException('Param2 has to be one of \'off\', \'reject\', \'silent\', \'off\'.');
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPDeviceUpdateAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPDeviceUpdateAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SCCPDeviceUpdate action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceUpdateAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * 
+     * @return void
+     */
+    public function __construct($DeviceName)
+    {
+        parent::__construct('SCCPDeviceUpdate');
+        
+        $this->setKey('DeviceName', $DeviceName);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPDndDeviceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPDndDeviceAction.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * SCCPDndDevice action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use PAMI\Exception\PAMIException;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDndDeviceAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceId DeviceId
+     * @param string $State State on of ['off', 'reject', 'silent']
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $State)
+    {
+        parent::__construct('SCCPDndDevice');
+        
+        $this->setKey('DeviceId', $DeviceName);
+        if (in_array(strtolower($State), array('off', 'reject', 'silent'))) {
+		    $this->setKey('State', $State);
+	    } else {
+	        throw new PAMIException('State has to be one of \'off\', \'reject\', \'silent\'.');
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPHangupCallAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPHangupCallAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SCCPHangupCall action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPHangupCallAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $ChannelId Id of the Channel to Hangup
+     *
+     * @return void
+     */
+    public function __construct($ChannelId)
+    {
+        parent::__construct('SCCPHangupCall');
+        
+        $this->setKey('ChannelId', $ChannelId);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPHoldCallAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPHoldCallAction.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * SCCPHoldCall action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use PAMI\Exception\PAMIException;
+
+/**
+ * Hold/Resume SCCP Sevice action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPHoldCallAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $CHannelId ChannelId
+     * @param boolean $Hold Hold or Resume
+     * @param string $DeviceName Required for SharedLine
+     * @param boolean $SwapChannels If we are resuming and have an active channel, should it be put on hold
+     *
+     * @return void
+     */
+    public function __construct($ChannelId, $DeviceName, $Hold = true, $SwapChannels = false)
+    {
+        parent::__construct('SCCPHoldCall');
+        
+        $this->setKey('ChannelId', $ChannelId);
+        $this->setKey('DeviceName', $DeviceName);
+        if ($Hold == true) {
+            $this->setKey('Hold', 'on');
+            if ($SwapChannels == true) {
+    	        throw new PAMIException('Cannot SwapChannels when putting on hold.');
+            }
+            $this->setKey('SwapChannels', 'off');
+        } else {
+            $this->setKey('Hold', 'off');
+            if ($SwapChannels == true) {
+                $this->setKey('SwapChannels', 'on');
+            } else {
+                $this->setKey('SwapChannels', 'off');
+            }
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPLineForwardUpdateAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPLineForwardUpdateAction.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * SCCPLineForwardUpdate action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+use PAMI\Exception\PAMIException;
+
+/**
+ * SCCP Forward Line action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPLineForwardUpdateAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * @param string $LineName Line Name
+     * @param string $ForwardType Forward Type, one of ['all', 'busy']
+     * @param boolean $Disable
+     * @param boolean $Number
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $LineName, $ForwardType, $Disable=false, $Number=false)
+    {
+        parent::__construct('SCCPLineForwardUpdate');
+        
+        $this->setKey('DeviceName', $DeviceName);
+        $this->setKey('LineName', $LineName);
+
+        if (in_array(strtolower($ForwardType), array('all', 'busy'))) {
+		    $this->setKey('ForwardType', $ForwardType);
+        } else {
+            throw new PAMIException('ForwardType has to be one of \'all\', \'busy\'.');
+        }
+
+        if ($Disable == true) {
+            $this->setKey('Disable', 'on');
+            if ($Number != false) {
+                throw new PAMIException('Number is missing.');
+            }
+        } else {
+            if ($Number != false) {
+                $this->setKey('Number', $Number);
+            } else {
+                throw new PAMIException('Number is missing.');
+            }
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPMessageDeviceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPMessageDeviceAction.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * SCCPMessageDevice action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPMessageDeviceAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName DeviceName
+     * @param string $MessageText Text to Send
+     * @param boolean $Beep optional
+     * @param integer $TImeout optional
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $MessageText, $Beep=false, $Timeout=false)
+    {
+        parent::__construct('SCCPMessageDevice');
+
+        $this->setKey('DeviceId', $DeviceName);
+        $this->setKey('MessageText', $MessageText);
+
+        if ($Beep != false) {
+	        $this->setKey('Beep', 'beep');
+        }
+
+        if ($Timeout != false) {
+        	$this->setKey('Timeout', intval($Timeout));
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPMessageDevicesAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPMessageDevicesAction.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * SCCPMessageDevices action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPMessageDevicesAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $MessageText Text to Send
+     * @param boolean $Beep optional
+     * @param integer $TImeout optional
+     *
+     * @return void
+     */
+    public function __construct($MessageText, $Beep=false, $Timeout=false)
+    {
+        parent::__construct('SCCPMessageDevices');
+        
+        $this->setKey('MessageText', $MessageText);
+
+        if ($Beep != false) {
+	        $this->setKey('Beep', 'beep');
+	}
+
+        if ($Timeout != false) {
+        	$this->setKey('Timeout', intval($Timeout));
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowChannelsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowChannelsAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * SCCPShowChannels action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowChannelsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowChannels');
+
+        /* manually overwrite the responsehandler */
+        $this->setResponseHandler('SCCPGeneric');
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowConferenceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowConferenceAction.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * SCCPShowConference action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowConferenceAction extends ActionMessage
+{
+	
+    /**
+     * Constructor.
+     *
+     * @param string $ConferenceId ConferenceId
+     *
+     * @return void
+     */
+    public function __construct($ConferenceId)
+    {
+        parent::__construct('SCCPShowConference');
+        $this->setResponseHandler("SCCPGeneric");
+        $this->setKey('ConferenceId', $ConferenceId);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowConferencesAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowConferencesAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowConferences action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowConferencesAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowConferences');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowDeviceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowDeviceAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SCCPShowDevice action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDeviceAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * 
+     * @return void
+     */
+    public function __construct($devicename)
+    {
+        parent::__construct('SCCPShowDevice');
+        $this->setResponseHandler("SCCPGeneric");
+        $this->setKey('DeviceName', $devicename);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowDeviceAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowDeviceAction.php
@@ -53,7 +53,6 @@ class SCCPShowDeviceAction extends ActionMessage
     public function __construct($devicename)
     {
         parent::__construct('SCCPShowDevice');
-        $this->setResponseHandler("SCCPGeneric");
         $this->setKey('DeviceName', $devicename);
     }
 }

--- a/src/mg/PAMI/Message/Action/SCCPShowDevicesAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowDevicesAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowDevices action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDevicesAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowDevices');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowGlobalsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowGlobalsAction.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * SCCPShowGlobals action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowGlobalsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowGlobals');
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowHintLineStatesAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowHintLineStatesAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowHintLineStates action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowHintLineStatesAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowHintLineStates');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowHintSubscriptionsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowHintSubscriptionsAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowHintSubscriptions action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowHintSubscriptionsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowHintSubscriptions');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowLineAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowLineAction.php
@@ -53,7 +53,6 @@ class SCCPShowLineAction extends ActionMessage
     public function __construct($linename)
     {
         parent::__construct('SCCPShowLine');
-        $this->setResponseHandler("SCCPGeneric");
         $this->setKey('LineName', $linename);
     }
 }

--- a/src/mg/PAMI/Message/Action/SCCPShowLineAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowLineAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SCCPShowLine action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLineAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $LineName Line Name
+     *
+     * @return void
+     */
+    public function __construct($linename)
+    {
+        parent::__construct('SCCPShowLine');
+        $this->setResponseHandler("SCCPGeneric");
+        $this->setKey('LineName', $linename);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowLinesAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowLinesAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowLines action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLinesAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowLines');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowMWISubscriptionsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowMWISubscriptionsAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowMWISubscriptions action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowMWISubscriptionsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowMWISubscriptions');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowSessionsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowSessionsAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowSessions action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowSessionsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowSessions');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPShowSoftkeySetsAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPShowSoftkeySetsAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * SCCPShowSoftkeySets action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowSoftkeySetsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('SCCPShowSoftkeySets');
+        $this->setResponseHandler("SCCPGeneric");
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPStartCallAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPStartCallAction.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * SCCPStartCall action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPStartCallAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceName Device Name
+     * @param string $LineName Line Name
+     * @param string $Number Extension to Ring
+     *
+     * @return void
+     */
+    public function __construct($DeviceName, $LineName, $Number)
+    {
+        parent::__construct('SCCPStartCall');
+        
+        $this->setKey('DeviceName', $DeviceName);
+        $this->setKey('LineName', $LineName);
+        $this->setKey('Number', $Number);
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPSystemMessageAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPSystemMessageAction.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * SCCPSystemMessage action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPSystemMessageAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $MessageText Text to Send
+     * @param boolean $Beep optional
+     * @param integer $TImeout optional
+     *
+     * @return void
+     */
+    public function __construct($MessageText, $Beep=false, $Timeout=false)
+    {
+        parent::__construct('SCCPSystemMessage');
+        
+        $this->setKey('MessageText', $MessageText);
+
+        if ($Beep != false) {
+	        $this->setKey('Beep', 'beep');
+	}
+
+        if ($Timeout != false) {
+        	$this->setKey('Timeout', intval($Timeout));
+        }
+    }
+}

--- a/src/mg/PAMI/Message/Action/SCCPTokenAckAction.php
+++ b/src/mg/PAMI/Message/Action/SCCPTokenAckAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * SCCPTokenAck action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Hangup action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPTokenAckAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $DeviceId DeviceId
+     *
+     * @return void
+     */
+    public function __construct($DeviceName)
+    {
+        parent::__construct('SCCPTokenAck');
+        $this->setKey('DeviceId', $DeviceName);
+    }
+}

--- a/src/mg/PAMI/Message/Event/CallAnsweredEvent.php
+++ b/src/mg/PAMI/Message/Event/CallAnsweredEvent.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Call Answered' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Call Answered' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class CallAnsweredEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'Channel'.
+	 *
+	 * @return string
+	 */
+	public function getChannel()
+	{
+      return $this->getKey('Channel');
+	}
+
+	/**
+	 * Returns key: 'SCCPLine'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPLine()
+	{
+      return $this->getKey('SCCPLine');
+	}
+
+	/**
+	 * Returns key: 'SCCPDevice'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPDevice()
+	{
+      return $this->getKey('SCCPDevice');
+	}
+
+	/**
+	 * Returns key: 'Uniqueid'.
+	 *
+	 * @return string
+	 */
+	public function getUniqueid()
+	{
+      return $this->getKey('Uniqueid');
+	}
+
+	/**
+	 * Returns key: 'CallingPartyNumber'.
+	 *
+	 * @return string
+	 */
+	public function getCallingPartyNumber()
+	{
+      return $this->getKey('CallingPartyNumber');
+	}
+
+	/**
+	 * Returns key: 'CallingPartyName'.
+	 *
+	 * @return string
+	 */
+	public function getCallingPartyName()
+	{
+      return $this->getKey('CallingPartyName');
+	}
+
+	/**
+	 * Returns key: 'originalCallingParty'.
+	 *
+	 * @return string
+	 */
+	public function getoriginalCallingParty()
+	{
+      return $this->getKey('originalCallingParty');
+	}
+
+	/**
+	 * Returns key: 'lastRedirectingParty'.
+	 *
+	 * @return string
+	 */
+	public function getlastRedirectingParty()
+	{
+      return $this->getKey('lastRedirectingParty');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/CallForwardEvent.php
+++ b/src/mg/PAMI/Message/Event/CallForwardEvent.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Event triggered when the 'SCCPCallForward' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCPCallForward' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class CallForwardEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Feature'.
+	 *
+	 * @return string
+	 */
+	public function getFeature()
+	{
+      return $this->getKey('Feature');
+	}
+
+	/**
+	 * Returns key: 'Status'.
+	 *
+	 * @return boolean
+	 */
+	public function getStatus()
+	{
+      return $this->getBoolKey('Status');
+	}
+
+	/**
+	 * Returns key: 'Extension'.
+	 *
+	 * @return string
+	 */
+	public function getExtension()
+	{
+      return $this->getKey('Extension');
+	}
+
+	/**
+	 * Returns key: 'SCCPLine'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPLine()
+	{
+      return $this->getKey('SCCPLine');
+	}
+
+	/**
+	 * Returns key: 'SCCPDevice'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPDevice()
+	{
+      return $this->getKey('SCCPDevice');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/DNDEvent.php
+++ b/src/mg/PAMI/Message/Event/DNDEvent.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Do Not Disturb' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Do Not Disturb' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class DNDEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Feature'.
+	 *
+	 * @return string
+	 */
+	public function getFeature()
+	{
+      return $this->getKey('Feature');
+	}
+
+	/**
+	 * Returns key: 'Status'.
+	 *
+	 * @return string
+	 */
+	public function getStatus()
+	{
+      return $this->getKey('Status');
+	}
+
+	/**
+	 * Returns key: 'SCCPDevice'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPDevice()
+	{
+      return $this->getKey('SCCPDevice');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/DeviceStatusEvent.php
+++ b/src/mg/PAMI/Message/Event/DeviceStatusEvent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Device Status' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Device Status' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class DeviceStatusEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'DeviceStatus'.
+	 *
+	 * @return string
+	 */
+	public function getDeviceStatus()
+	{
+      return $this->getKey('DeviceStatus');
+	}
+
+	/**
+	 * Returns key: 'SCCPDevice'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPDevice()
+	{
+      return $this->getKey('SCCPDevice');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -33,6 +33,7 @@ namespace PAMI\Message\Event\Factory\Impl;
 use PAMI\Message\Event\EventMessage;
 use PAMI\Message\Event\UnknownEvent;
 use PAMI\Message\Message;
+use PAMI\Exception\PAMIException;
 
 /**
  * This factory knows which event to return according to a given raw message
@@ -70,10 +71,18 @@ class EventFactoryImpl
         }
         $name = substr($message, $eventStart, $eventEnd - $eventStart);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
-        if (class_exists($className, true)) {
-            return new $className($message);
-        }
-	    return new UnknownEvent($message);
+		if (class_exists($className, true)) {
+			try {
+				return new $className($message);
+			} catch (PAMIException $e) {
+				throw $e;
+			}
+		}
+		try {
+			return new UnknownEvent($message);
+		} catch (PAMIException $e) {
+			throw $e;
+		}
     }
 
     /**

--- a/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -50,6 +50,8 @@ use PAMI\Exception\PAMIException;
  */
 class EventFactoryImpl
 {
+	private $_logger;
+
     /**
      * This is our factory method.
      *
@@ -57,7 +59,8 @@ class EventFactoryImpl
      *
      * @return EventMessage
      */
-    public static function createFromRaw($message)
+//    public static function createFromRaw($message)
+    public function createFromRaw($message)
     {
         $eventStart = strpos($message, 'Event: ') + 7;
 /*
@@ -72,17 +75,11 @@ class EventFactoryImpl
         $name = substr($message, $eventStart, $eventEnd - $eventStart);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
 		if (class_exists($className, true)) {
-			try {
-				return new $className($message);
-			} catch (PAMIException $e) {
-				throw $e;
-			}
+			if ($this->_logger->isDebugEnabled()) $this->_logger->debug("Created: " . $className . "\n");
+			return new $className($message);
 		}
-		try {
-			return new UnknownEvent($message);
-		} catch (PAMIException $e) {
-			throw $e;
-		}
+ 		if ($this->_logger->isDebugEnabled()) $this->_logger->debug("Created: " . '\\PAMI\\Message\\Event\\UnknownEvent' . "\n");
+		return new UnknownEvent($message);
     }
 
     /**
@@ -90,7 +87,9 @@ class EventFactoryImpl
      *
      * @return void
      */
-    public function __construct()
+    public function __construct($logger)
     {
+		$this->_logger = $logger ? $logger : \Logger::getLogger(__CLASS__);
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('------ Event Factory Created: ------ ' . "\n");
     }
 }

--- a/src/mg/PAMI/Message/Event/RequestBadFormatEvent.php
+++ b/src/mg/PAMI/Message/Event/RequestBadFormatEvent.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class RequestBadFormatEvent extends EventMessage
+{
+
+    /**
+     * Returns key: 'Privilege'.
+     *
+     * @return string
+     */
+    public function getPrivilege()
+    {
+        return $this->getKey('Privilege');
+    }
+
+    /**
+     * Returns key: 'SequenceNumber'.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->getKey('SequenceNumber');
+    }
+
+    /**
+     * Returns key: 'File'.
+     *
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->getKey('File');
+    }
+
+    /**
+     * Returns key: 'Line'.
+     *
+     * @return int
+     */
+    public function getLine()
+    {
+        return $this->getKey('Line');
+    }
+
+    /**
+     * Returns key: 'Func'.
+     *
+     * @return string
+     */
+    public function getFunc()
+    {
+        return $this->getKey('Func');
+    }
+
+    /**
+     * Returns key: 'EventTV'.
+     *
+     * @return string
+     */
+    public function getEventTV()
+    {
+        return $this->getKey('EventTV');
+    }
+
+    /**
+     * Returns key: 'Severity'.
+     *
+     * @return string
+     */
+    public function getSeverity()
+    {
+        return $this->getKey('Severity');
+    }
+    
+    /**
+     * Returns key: 'Service'.
+     *
+     * @return string
+     */
+    public function getService()
+    {
+        return $this->getKey('Service');
+    }
+
+    /**
+     * Returns key: 'EventVersion'.
+     *
+     * @return int
+     */
+    public function getEventVersion()
+    {
+        return $this->getKey('EventVersion');
+    }
+
+    /**
+     * Returns key: 'AccountID'.
+     *
+     * @return string
+     */
+    public function getAccountID()
+    {
+        return $this->getKey('AccountID');
+    }
+
+    /**
+     * Returns key: 'SessionID'.
+     *
+     * @return string
+     */
+    public function getSessionID()
+    {
+        return $this->getKey('SessionID');
+    }
+
+    /**
+     * Returns key: 'LocalAddress'.
+     *
+     * @return string
+     */
+    public function getLocalAddress()
+    {
+        return $this->getKey('LocalAddress');
+    }
+
+    /**
+     * Returns key: 'RemoteAddress'.
+     *
+     * @return string
+     */
+    public function getRemoteAddress()
+    {
+        return $this->getKey('RemoteAddress');
+    }
+
+    /**
+     * Returns key: 'UsingPassword'.
+     *
+     * @return boolean
+     */
+    public function getUsingPassword()
+    {
+        return $this->getBoolKey('UsingPassword');
+    }
+
+    /**
+     * Returns key: 'SessionTV'.
+     *
+     * @return string
+     */
+    public function getSessionTV()
+    {
+        return $this->getKey('SessionTV');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPAttachedDeviceEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPAttachedDeviceEntryEvent.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPAttachedDeviceEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Device Name'.
+     *
+     * @return string
+     */
+    public function getDeviceName()
+    {
+        return $this->getKey('DeviceName');
+    }
+
+    /**
+     * Returns key: 'Type of CallForward'.
+     *
+     * @return string
+     */
+    public function getCfwdType()
+    {
+        return $this->getKey('CfwdType');
+    }
+
+    /**
+     * Returns key: 'Forwaring to Number'.
+     *
+     * @return string
+     */
+    public function getCfwdNumber()
+    {
+        return $this->getKey('CfwdNumber');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPChannelEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPChannelEntryEvent.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPChannelEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'ID'.
+     *
+     * @return integer
+     */
+    public function getID()
+    {
+        return intval($this->getKey('ID'));
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'LineName'.
+     *
+     * @return string
+     */
+    public function getLineName()
+    {
+        return $this->getKey('LineName');
+    }
+
+    /**
+     * Returns key: 'DeviceName'.
+     *
+     * @return string
+     */
+    public function getDeviceName()
+    {
+        return $this->getKey('DeviceName');
+    }
+
+    /**
+     * Returns key: 'NumCalled'.
+     *
+     * @return string
+     */
+    public function getNumCalled()
+    {
+        return $this->getKey('NumCalled');
+    }
+
+    /**
+     * Returns key: 'PBX State'.
+     *
+     * @return string
+     */
+    public function getPBXState()
+    {
+        return $this->getKey('PBXState');
+    }
+
+    /**
+     * Returns key: 'SCCP State'.
+     *
+     * @return string
+     */
+    public function getSCCPState()
+    {
+        return $this->getKey('SCCPState');
+    }
+
+    /**
+     * Returns key: 'ReadCodec'.
+     *
+     * @return string
+     */
+    public function getReadCodec()
+    {
+        return $this->getKey('ReadCodec');
+    }
+
+    /**
+     * Returns key: 'WriteCodec'.
+     *
+     * @return string
+     */
+    public function getWriteCodec()
+    {
+        return $this->getKey('WriteCodec');
+    }
+
+    /**
+     * Returns key: 'RTPPeer'.
+     *
+     * @return string
+     */
+    public function getRTPPeer()
+    {
+        return $this->getKey('RTPPeer');
+    }
+
+    /**
+     * Returns key: 'Direct Media (Direct RTP)'.
+     *
+     * @return boolean
+     */
+    public function getDirectMedia()
+    {
+        return $this->getBoolKey('Direct');
+    }
+
+    /**
+     * Returns key: 'DTMFmode'.
+     *
+     * @return string
+     */
+    public function getDTMFmode()
+    {
+        return $this->getKey('DTMFmode');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfEndEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfEndEvent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference End' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference End' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfEndEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfEnteredEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfEnteredEvent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Entered' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Entered' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfEnteredEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+	/**
+	 * Returns key: 'Channel'.
+	 *
+	 * @return string
+	 */
+	public function getChannel()
+	{
+      return $this->getKey('Channel');
+	}
+
+	/**
+	 * Returns key: 'Uniqueid'.
+	 *
+	 * @return string
+	 */
+	public function getUniqueid()
+	{
+      return $this->getKey('Uniqueid');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfLeaveEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfLeaveEvent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Leave' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Leave' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfLeaveEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+	/**
+	 * Returns key: 'Channel'.
+	 *
+	 * @return string
+	 */
+	public function getChannel()
+	{
+      return $this->getKey('Channel');
+	}
+
+	/**
+	 * Returns key: 'Uniqueid'.
+	 *
+	 * @return string
+	 */
+	public function getUniqueid()
+	{
+      return $this->getKey('Uniqueid');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfLeftEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfLeftEvent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Left' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Left' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfLeftEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+	/**
+	 * Returns key: 'Channel'.
+	 *
+	 * @return string
+	 */
+	public function getChannel()
+	{
+      return $this->getKey('Channel');
+	}
+
+	/**
+	 * Returns key: 'Uniqueid'.
+	 *
+	 * @return string
+	 */
+	public function getUniqueid()
+	{
+      return $this->getKey('Uniqueid');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfLockEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfLockEvent.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Lock' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Lock' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfLockEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'Enabled'.
+	 *
+	 * @return integer
+	 */
+	public function getEnabled()
+	{
+      return $this->getBoolKey('Enabled');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfParticipantKickedEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfParticipantKickedEvent.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Participant Kicked' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Participant Kicked' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfParticipantKickedEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfParticipantMuteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfParticipantMuteEvent.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Participant Mute' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Participant Mute' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfParticipantMuteEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+	/**
+	 * Returns key: 'Mute'.
+	 *
+	 * @return boolean
+	 */
+	public function getMute()
+	{
+      return $this->getBoolKey('Mute');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfParticipantPromotionEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfParticipantPromotionEvent.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Participant Promotion' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Participant Promotion' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfParticipantPromotionEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'PartId'.
+	 *
+	 * @return integer
+	 */
+	public function getPartId()
+	{
+      return intval($this->getKey('PartId'));
+	}
+
+	/**
+	 * Returns key: 'Moderator'.
+	 *
+	 * @return boolean
+	 */
+	public function getModerator()
+	{
+      return $this->getBoolKey('Moderator');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfStartEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfStartEvent.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Start' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Start' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfStartEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+	/**
+	 * Returns key: 'SCCPDevice'.
+	 *
+	 * @return string
+	 */
+	public function getSCCPDevice()
+	{
+      return $this->getKey('SCCPDevice');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConfStartedEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConfStartedEvent.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Event triggered when the 'SCCP Conference Started' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when the 'SCCP Conference Started' Event arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConfStartedEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ConfId'.
+	 *
+	 * @return integer
+	 */
+	public function getConfId()
+	{
+      return intval($this->getKey('ConfId'));
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPConferenceEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPConferenceEntryEvent.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Event triggered when SCCPConferenceEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPConferenceEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPConferenceEntryEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Id'.
+	 *
+	 * @return integer
+	 */
+	public function getId()
+	{
+      return intval($this->getKey('Id'));
+	}
+
+	/**
+	 * Returns key: 'Participants'.
+	 *
+	 * @return integer
+	 */
+	public function getParticipants()
+	{
+      return intval($this->getKey('Participants'));
+	}
+
+	/**
+	 * Returns key: 'Moderators'.
+	 *
+	 * @return integer
+	 */
+	public function getModerators()
+	{
+      return intval($this->getKey('Moderators'));
+	}
+
+	/**
+	 * Returns key: 'Announce'.
+	 *
+	 * @return boolean
+	 */
+	public function getAnnounce()
+	{
+      return $this->getBoolKey('Announce');
+	}
+
+	/**
+	 * Returns key: 'MuteOnEntry'.
+	 *
+	 * @return boolean
+	 */
+	public function getMuteOnEntry()
+	{
+      return $this->getBoolKey('MuteOnEntry');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceButtonEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceButtonEntryEvent.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceButtonEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Id'.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return intval($this->getKey('Id'));
+    }
+
+    /**
+     * Returns key: 'Inst'.
+     *
+     * @return integer
+     */
+    public function getInst()
+    {
+        return intval($this->getKey('Inst'));
+    }
+
+    /**
+     * Returns key: 'TypeStr'.
+     *
+     * @return string
+     */
+    public function getTypeStr()
+    {
+        return $this->getKey('TypeStr');
+    }
+
+    /**
+     * Returns key: 'Type'.
+     *
+     * @return integer
+     */
+    public function getType()
+    {
+        return intval($this->getKey('Type'));
+    }
+
+    /**
+     * Returns key: 'PendingDelete'.
+     *
+     * @return boolean
+     */
+    public function getPendingDelete()
+    {
+    	return $this->getBoolKey('pendDel');
+    }
+
+    /**
+     * Returns key: 'PendingUpdate'.
+     *
+     * @return boolean
+     */
+    public function getPendingUpdate()
+    {
+    	return $this->getBoolKey('pendUpdt');
+    }
+
+    /**
+     * Returns key: 'Default'.
+     *
+     * @return boolean
+     */
+    public function getDefault()
+    {
+    	return $this->getBoolKey('Default');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceEntryEvent.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->getKey('Descr');
+    }
+
+    /**
+     * Returns key: 'Address'.
+     *
+     * @return string
+     */
+    public function getAddress()
+    {
+        return $this->getKey('Address');
+    }
+
+    /**
+     * Returns key: 'Mac'.
+     *
+     * @return string
+     */
+    public function getMac()
+    {
+        return $this->getKey('Mac');
+    }
+
+    /**
+     * Returns key: 'RegState'.
+     *
+     * @return string
+     */
+    public function getRegState()
+    {
+        return $this->getKey('RegState');
+    }
+
+    /**
+     * Returns key: 'Token'.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->getKey('Token');
+    }
+
+    /**
+     * Returns key: 'RegistrationTime'.
+     *
+     * @return string
+     */
+    public function getRegTime()
+    {
+        return $this->getKey('RegTime');
+    }
+
+    /**
+     * Returns key: 'Active'.
+     *
+     * @return boolean
+     */
+    public function getActive()
+    {
+        return $this->getBoolKey('Act');
+    }
+
+    /**
+     * Returns key: 'Lines'.
+     *
+     * @return int
+     */
+    public function getLines()
+    {
+        return intval($this->getKey('Lines'));
+    }
+
+    /**
+     * Returns key: 'Nat'.
+     *
+     * @return string
+     */
+    public function getNat()
+    {
+        return $this->getKey('Nat');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceFeatureEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceFeatureEntryEvent.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceFeatureEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Id'.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return intval($this->getKey('Id'));
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'Options'.
+     *
+     * @return string
+     */
+    public function getOptions()
+    {
+        return $this->getKey('Options');
+    }
+
+    /**
+     * Returns key: 'Status'.
+     *
+     * @return integer
+     */
+    public function getStatus()
+    {
+        return intval($this->getKey('Status'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceLineEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceLineEntryEvent.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceLineEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Id'.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return intval($this->getKey('Id'));
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'Suffix'.
+     *
+     * @return integer
+     */
+    public function getSuffix()
+    {
+        return intval($this->getKey('Suffix'));
+    }
+
+    /**
+     * Returns key: 'Label'.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->getKey('Label');
+    }
+
+    /**
+     * Returns key: 'CfwdType'.
+     *
+     * @return string
+     */
+    public function getCfwdType()
+    {
+        return $this->getKey('CfwdType');
+    }
+
+    /**
+     * Returns key: 'CfwdNumber'.
+     *
+     * @return string
+     */
+    public function getCfwdNumber()
+    {
+        return $this->getKey('CfwdNumber');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceServiceURLEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceServiceURLEntryEvent.php
@@ -95,14 +95,4 @@ class SCCPDeviceServiceURLEntryEvent extends EventMessage
         return $this->getKey('URL');
     }
 
-    /**
-     * Returns key: 'Status'.
-     *
-     * @return string
-     */
-    public function getStatus()
-    {
-        return $this->getKey('Status');
-    }
-
 }

--- a/src/mg/PAMI/Message/Event/SCCPDeviceServiceURLEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceServiceURLEntryEvent.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceServiceURLEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Id'.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return intval($this->getKey('Id'));
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'URL'.
+     *
+     * @return string
+     */
+    public function getURL()
+    {
+        return $this->getKey('URL');
+    }
+
+    /**
+     * Returns key: 'Status'.
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->getKey('Status');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceSpeeddialEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceSpeeddialEntryEvent.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceSpeeddialEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+    /**
+     * Returns key: 'Id'.
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return intval($this->getKey('Id'));
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'Number'.
+     *
+     * @return string
+     */
+    public function getNumber()
+    {
+        return $this->getKey('Number');
+    }
+
+    /**
+     * Returns key: 'Hint'.
+     *
+     * @return string
+     */
+    public function getHint()
+    {
+        return $this->getKey('Hint');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPDeviceStatisticsEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPDeviceStatisticsEntryEvent.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPDeviceStatisticsEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Type'.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getKey('Type');
+    }
+
+    /**
+     * Returns key: 'Calls'.
+     *
+     * @return integer
+     */
+    public function getCalls()
+    {
+        return intval($this->getKey('Calls'));
+    }
+
+    /**
+     * Returns key: 'Packets Sent'.
+     *
+     * @return integer
+     */
+    public function getPacketsSent()
+    {
+        return intval($this->getKey('PcktSnt'));
+    }
+
+    /**
+     * Returns key: 'Packets Received'.
+     *
+     * @return integer
+     */
+    public function getPacketsReceived()
+    {
+        return intval($this->getKey('PcktRcvd'));
+    }
+
+    /**
+     * Returns key: 'Packets Lost'.
+     *
+     * @return integer
+     */
+    public function getPacketsLost()
+    {
+        return intval($this->getKey('Lost'));
+    }
+
+    /**
+     * Returns key: 'Jitter'.
+     *
+     * @return integer
+     */
+    public function getJitter()
+    {
+        return intval($this->getKey('Jitter'));
+    }
+
+    /**
+     * Returns key: 'Latency'.
+     *
+     * @return integer
+     */
+    public function getLatency()
+    {
+        return intval($this->getKey('Latency'));
+    }
+
+    /**
+     * Returns key: 'Quality'.
+     *
+     * @return float
+     */
+    public function getQuality()
+    {
+        return floatval($this->getKey('Quality'));
+    }
+
+    /**
+     * Returns key: 'Average Quality'.
+     *
+     * @return float
+     */
+    public function getAverageQuality()
+    {
+        return floatval($this->getKey('avgQual'));
+    }
+
+    /**
+     * Returns key: 'Mean Quality'.
+     *
+     * @return float
+     */
+    public function getMeanQuality()
+    {
+        return floatval($this->getKey('meanQual'));
+    }
+
+    /**
+     * Returns key: 'Maximum Quality'.
+     *
+     * @return float
+     */
+    public function getMaxQuality()
+    {
+        return floatval($this->getKey('maxQual'));
+    }
+
+    /**
+     * Returns key: 'ReceivedConcealed'.
+     *
+     * @return float
+     */
+    public function getReceivedConcealed()
+    {
+        return floatval($this->getKey('rConceal'));
+    }
+
+    /**
+     * Returns key: 'sConceal'.
+     *
+     * @return integer
+     */
+    public function getSentConcealed()
+    {
+        return intval($this->getKey('sConceal'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPHintLineStateEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPHintLineStateEntryEvent.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Event triggered when SCCPHintLineStateEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPHintLineStateEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPHintLineStateEntryEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'LineName'.
+	 *
+	 * @return string
+	 */
+	public function getLineName()
+	{
+      return $this->getKey('LineName');
+	}
+
+	/**
+	 * Returns key: 'State'.
+	 *
+	 * @return string
+	 */
+	public function getState()
+	{
+      return $this->getKey('State');
+	}
+
+	/**
+	 * Returns key: 'CallInfoNumber:'.
+	 *
+	 * @return string
+	 */
+	public function getCallInfoNumber()
+	{
+      return $this->getKey('CallInfoNumber:');
+	}
+
+	/**
+	 * Returns key: 'CallInfoName:'.
+	 *
+	 * @return string
+	 */
+	public function getCallInfoName()
+	{
+      return $this->getKey('CallInfoName:');
+	}
+
+	/**
+	 * Returns key: 'Direction'.
+	 *
+	 * @return string
+	 */
+	public function getDirection()
+	{
+      return $this->getKey('Direction');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPHintSubscriptionEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPHintSubscriptionEntryEvent.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Event triggered when SCCPHintSubscriptionEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPHintSubscriptionEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPHintSubscriptionEntryEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Exten'.
+	 *
+	 * @return string
+	 */
+	public function getExten()
+	{
+      return $this->getKey('Exten');
+	}
+
+	/**
+	 * Returns key: 'Context'.
+	 *
+	 * @return string
+	 */
+	public function getContext()
+	{
+      return $this->getKey('Context');
+	}
+
+	/**
+	 * Returns key: 'Hint'.
+	 *
+	 * @return string
+	 */
+	public function getHint()
+	{
+      return $this->getKey('Hint');
+	}
+
+	/**
+	 * Returns key: 'State'.
+	 *
+	 * @return string
+	 */
+	public function getState()
+	{
+      return $this->getKey('State');
+	}
+
+	/**
+	 * Returns key: 'CallInfoNumber:'.
+	 *
+	 * @return string
+	 */
+	public function getCallInfoNumber()
+	{
+      return $this->getKey('CallInfoNumber:');
+	}
+
+	/**
+	 * Returns key: 'CallInfoName:'.
+	 *
+	 * @return string
+	 */
+	public function getCallInfoName()
+	{
+      return $this->getKey('CallInfoName:');
+	}
+
+	/**
+	 * Returns key: 'Direction:'.
+	 *
+	 * @return string
+	 */
+	public function getDirection()
+	{
+      return $this->getKey('Direction:');
+	}
+
+	/**
+	 * Returns key: 'Subs'.
+	 *
+	 * @return integer
+	 */
+	public function getSubs()
+	{
+      return intval($this->getKey('Subs'));
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPLineEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPLineEntryEvent.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPLineEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Exten'.
+     *
+     * @return string
+     */
+    public function getExten()
+    {
+        return $this->getKey('Exten');
+    }
+
+    /**
+     * Returns key: 'SubscriptionNumber'.
+     *
+     * @return string
+     */
+    public function getSubscriptionNumber()
+    {
+        return $this->getKey('SubscriptionNumber');
+    }
+
+    /**
+     * Returns key: 'Label'.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->getKey('Label');
+    }
+
+    /**
+     * Returns key: 'Device'.
+     *
+     * @return string
+     */
+    public function getDevice()
+    {
+        return $this->getKey('Device');
+    }
+
+    /**
+     * Returns key: 'MWI'.
+     *
+     * @return string
+     */
+    public function getMWI()
+    {
+        return $this->getKey('MWI');
+    }
+
+    /**
+     * Returns key: 'ActiveChannels'.
+     *
+     * @return string
+     */
+    public function getActiveChannels()
+    {
+        return $this->getKey('ActiveChannels');
+    }
+
+    /**
+     * Returns key: 'ChannelState'.
+     *
+     * @return string
+     */
+    public function getChannelState()
+    {
+        return $this->getKey('ChannelState');
+    }
+
+    /**
+     * Returns key: 'CallType'.
+     *
+     * @return string
+     */
+    public function getCallType()
+    {
+        return $this->getKey('CallType');
+    }
+
+    /**
+     * Returns key: 'PartyName'.
+     *
+     * @return string
+     */
+    public function getPartyName()
+    {
+        return $this->getKey('PartyName');
+    }
+
+    /**
+     * Returns key: 'Capabilities'.
+     *
+     * @return string
+     */
+    public function getCapabilities()
+    {
+        return $this->getKey('Capabilities');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPMailboxEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPMailboxEntryEvent.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPMailboxEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Mailbox Name'.
+     *
+     * @return string
+     */
+    public function getMailbox()
+    {
+        return $this->getKey('Mailbox');
+    }
+
+    /**
+     * Returns key: 'Mailbox Context'.
+     *
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->getKey('Context');
+    }
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPMailboxSubscriberEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPMailboxSubscriberEntryEvent.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Event triggered when SCCPMailboxSubscriberEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPMailboxSubscriberEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPMailboxSubscriberEntryEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Mailbox'.
+	 *
+	 * @return string
+	 */
+	public function getMailbox()
+	{
+      return $this->getKey('Mailbox');
+	}
+
+	/**
+	 * Returns key: 'LineName'.
+	 *
+	 * @return string
+	 */
+	public function getLineName()
+	{
+      return $this->getKey('LineName');
+	}
+
+	/**
+	 * Returns key: 'Context'.
+	 *
+	 * @return string
+	 */
+	public function getContext()
+	{
+      return $this->getKey('Context');
+	}
+
+	/**
+	 * Returns key: 'New'.
+	 *
+	 * @return integer
+	 */
+	public function getNew()
+	{
+      return intval($this->getKey('New'));
+	}
+
+	/**
+	 * Returns key: 'Old'.
+	 *
+	 * @return integer
+	 */
+	public function getOld()
+	{
+      return intval($this->getKey('Old'));
+	}
+
+	/**
+	 * Returns key: 'Sub'.
+	 *
+	 * @return boolean
+	 */
+	public function getSub()
+	{
+      return $this->getBoolKey('Sub');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPSessionEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPSessionEntryEvent.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPSessionEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Socket'.
+     *
+     * @return integer
+     */
+    public function getSocket()
+    {
+        return intval($this->getKey('Socket'));
+    }
+
+    /**
+     * Returns key: 'IP'.
+     *
+     * @return string
+     */
+    public function getIP()
+    {
+        return $this->getKey('IP');
+    }
+
+    /**
+     * Returns key: 'Port'.
+     *
+     * @return string
+     */
+    public function getPort()
+    {
+        return $this->getKey('Port');
+    }
+
+    /**
+     * Returns key: 'Current KeepAlive Value'.
+     *
+     * @return integer
+     */
+    public function getKeepAlive()
+    {
+        return $this->getKey('KA');
+    }
+
+    /**
+     * Returns key: 'KeepAlive Interval'.
+     *
+     * @return integer
+     */
+    public function getKeepAliveInterval()
+    {
+        return intval($this->getKey('KAI'));
+    }
+
+    /**
+     * Returns key: 'DeviceName'.
+     *
+     * @return string
+     */
+    public function getDeviceName()
+    {
+        return $this->getKey('DeviceName');
+    }
+
+    /**
+     * Returns key: 'State'.
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->getKey('State');
+    }
+
+    /**
+     * Returns key: 'Type'.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->getKey('Type');
+    }
+
+    /**
+     * Returns key: 'RegState'.
+     *
+     * @return string
+     */
+    public function getRegState()
+    {
+        return $this->getKey('RegState');
+    }
+
+    /**
+     * Returns key: 'Token'.
+     *
+     * @return string
+     */
+    public function getToken()
+    {
+        return $this->getKey('Token');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowChannelsCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowChannelsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowChannelsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowConferencesCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowConferencesCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when SCCPShowConferences Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPShowConferences Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowConferencesCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowDeviceCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowDeviceCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDeviceCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowDeviceEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowDeviceEvent.php
@@ -1,0 +1,725 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDeviceEvent extends EventMessage
+{
+    /**
+     * Returns key: 'MACAddress'.
+     *
+     * @return string
+     */
+    public function getMACAddress()
+    {
+        return $this->getKey('MACAddress');
+    }
+
+    /**
+     * Returns key: 'DeviceName'.
+     *
+     * @return string
+     */
+    public function getDeviceName()
+    {
+        return $this->getMACAddress();
+    }
+
+    /**
+     * Returns key: 'ProtocolVersion'.
+     *
+     * @return string
+     */
+    public function getProtocolVersion()
+    {
+        return $this->getKey('ProtocolVersion');
+    }
+
+    /**
+     * Returns key: 'ProtocolInUse'.
+     *
+     * @return string
+     */
+    public function getProtocolInUse()
+    {
+        return $this->getKey('ProtocolInUse');
+    }
+
+    /**
+     * Returns key: 'DeviceFeatures'.
+     *
+     * @return string
+     */
+    public function getDeviceFeatures()
+    {
+        return $this->getKey('DeviceFeatures');
+    }
+
+    /**
+     * Returns key: 'Tokenstate'.
+     *
+     * @return string
+     */
+    public function getTokenstate()
+    {
+        return $this->getKey('Tokenstate');
+    }
+
+    /**
+     * Returns key: 'Keepalive'.
+     *
+     * @return integer
+     */
+    public function getKeepalive()
+    {
+        return intval($this->getKey('Keepalive'));
+    }
+
+    /**
+     * Returns key: 'RegistrationState'.
+     *
+     * @return string
+     */
+    public function getRegistrationState()
+    {
+        return $this->getKey('RegistrationState');
+    }
+
+    /**
+     * Returns key: 'State'.
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->getKey('State');
+    }
+
+    /**
+     * Returns key: 'MWILight'.
+     *
+     * @return string
+     */
+    public function getMWILight()
+    {
+        return $this->getKey('MWILight');
+    }
+
+    /**
+     * Returns key: 'MWIHandsetLight'.
+     *
+     * @return boolean
+     */
+    public function getMWIHandsetLight()
+    {
+        return $this->getBoolKey('MWIHandsetLight');
+    }
+
+    /**
+     * Returns key: 'Description'.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->getKey('Description');
+    }
+
+    /**
+     * Returns key: 'ConfigPhoneType'.
+     *
+     * @return string
+     */
+    public function getConfigPhoneType()
+    {
+        return $this->getKey('ConfigPhoneType');
+    }
+
+    /**
+     * Returns key: 'SkinnyPhoneType'.
+     *
+     * @return string
+     */
+    public function getSkinnyPhoneType()
+    {
+        return $this->getKey('SkinnyPhoneType');
+    }
+
+    /**
+     * Returns key: 'SoftkeySupport'.
+     *
+     * @return boolean
+     */
+    public function getSoftkeySupport()
+    {
+        return $this->getBoolKey('SoftkeySupport');
+    }
+
+    /**
+     * Returns key: 'Softkeyset'.
+     *
+     * @return string
+     */
+    public function getSoftkeyset()
+    {
+        return $this->getKey('Softkeyset');
+    }
+
+    /**
+     * Returns key: 'BTemplateSupport'.
+     *
+     * @return boolean
+     */
+    public function getBTemplateSupport()
+    {
+        return $this->getBoolKey('BTemplateSupport');
+    }
+
+    /**
+     * Returns key: 'linesRegistered'.
+     *
+     * @return boolean
+     */
+    public function getLinesRegistered()
+    {
+        return $this->getBoolKey('linesRegistered');
+    }
+
+    /**
+     * Returns key: 'ImageVersion'.
+     *
+     * @return string
+     */
+    public function getImageVersion()
+    {
+        return $this->getKey('ImageVersion');
+    }
+
+    /**
+     * Returns key: 'TimezoneOffset'.
+     *
+     * @return integer
+     */
+    public function getTimezoneOffset()
+    {
+        return intval($this->getKey('TimezoneOffset'));
+    }
+
+    /**
+     * Returns key: 'Capabilities'.
+     *
+     * @return (string|int)[]
+     */
+    public function getCapabilities()
+    {
+    	$ret = array();
+    	$codecs=explode(", ", substr($this->getKey('Capabilities'), 1, -1));
+    	foreach($codecs as $codec) {
+    		$codec_parts=explode(" ", $codec);
+    		$ret[] = array("name" => $codec_parts[0], "value" => substr($codec_parts[1], 1, -1));
+    	}
+        return $ret;
+    }
+
+    /**
+     * Returns key: 'CodecsPreference'.
+     *
+     * @return (string|int)[]
+     */
+    public function getCodecsPreference()
+    {
+    	$ret = array();
+    	$codecs=explode(", ", substr($this->getKey('CodecsPreference'), 1, -1));
+    	foreach($codecs as $codec) {
+    		$codec_parts=explode(" ", $codec);
+    		$ret[] = array("name" => $codec_parts[0], "value" => substr($codec_parts[1], 1, -1));
+    	}
+        return $ret;
+    }
+
+    /**
+     * Returns key: 'AudioTOS'.
+     *
+     * @return integer
+     */
+    public function getAudioTOS()
+    {
+        return intval($this->getKey('AudioTOS'));
+    }
+
+    /**
+     * Returns key: 'AudioCOS'.
+     *
+     * @return integer
+     */
+    public function getAudioCOS()
+    {
+        return intval($this->getKey('AudioCOS'));
+    }
+
+    /**
+     * Returns key: 'VideoTOS'.
+     *
+     * @return integer
+     */
+    public function getVideoTOS()
+    {
+        return intval($this->getKey('VideoTOS'));
+    }
+
+    /**
+     * Returns key: 'VideoCOS'.
+     *
+     * @return integer
+     */
+    public function getVideoCOS()
+    {
+        return intval($this->getKey('VideoCOS'));
+    }
+
+    /**
+     * Returns key: 'DNDFeatureEnabled'.
+     *
+     * @return boolean
+     */
+    public function getDNDFeatureEnabled()
+    {
+        return $this->getBoolKey('DNDFeatureEnabled');
+    }
+
+    /**
+     * Returns key: 'DNDStatus'.
+     *
+     * @return string
+     */
+    public function getDNDStatus()
+    {
+        return $this->getKey('DNDStatus');
+    }
+
+    /**
+     * Returns key: 'DNDAction'.
+     *
+     * @return string
+     */
+    public function getDNDAction()
+    {
+        return $this->getKey('DNDAction');
+    }
+
+    /**
+     * Returns key: 'CanTransfer'.
+     *
+     * @return boolean
+     */
+    public function getCanTransfer()
+    {
+        return $this->getBoolKey('CanTransfer');
+    }
+
+    /**
+     * Returns key: 'CanPark'.
+     *
+     * @return boolean
+     */
+    public function getCanPark()
+    {
+        return $this->getBoolKey('CanPark');
+    }
+
+    /**
+     * Returns key: 'CanCFWDALL'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWDALL()
+    {
+        return $this->getBoolKey('CanCFWDALL');
+    }
+
+    /**
+     * Returns key: 'CanCFWBUSY'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWBUSY()
+    {
+        return $this->getBoolKey('CanCFWBUSY');
+    }
+
+    /**
+     * Returns key: 'CanCFWNOANSWER'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWNOANSWER()
+    {
+        return $this->getBoolKey('CanCFWNOANSWER');
+    }
+
+    /**
+     * Returns key: 'AllowRinginNotification'.
+     *
+     * @return boolean
+     */
+    public function getAllowRinginNotification()
+    {
+        return $this->getBoolKey('AllowRinginNotification');
+    }
+
+    /**
+     * Returns key: 'PrivateSoftkey'.
+     *
+     * @return boolean
+     */
+    public function getPrivateSoftkey()
+    {
+        return $this->getBoolKey('PrivateSoftkey');
+    }
+
+    /**
+     * Returns key: 'DtmfMode'.
+     *
+     * @return string
+     */
+    public function getDtmfMode()
+    {
+        return $this->getKey('DtmfMode');
+    }
+
+    /**
+     * Returns key: 'Nat'.
+     *
+     * @return string
+     */
+    public function getNat()
+    {
+        return $this->getKey('Nat');
+    }
+
+    /**
+     * Returns key: 'Videosupport'.
+     *
+     * @return boolean
+     */
+    public function getVideosupport()
+    {
+        return $this->getBoolKey('Videosupport');
+    }
+
+    /**
+     * Returns key: 'DirectRTP'.
+     *
+     * @return boolean
+     */
+    public function getDirectRTP()
+    {
+        return $this->getBoolKey('DirectRTP');
+    }
+
+    /**
+     * Returns key: 'BindAddress'.
+     *
+     * @return string
+     */
+    public function getBindAddress()
+    {
+        return $this->getKey('BindAddress');
+    }
+
+    /**
+     * Returns key: 'ServerAddress'.
+     *
+     * @return string
+     */
+    public function getServerAddress()
+    {
+        return $this->getKey('ServerAddress');
+    }
+
+    /**
+     * Returns key: 'DenyPermit'.
+     *
+     * @return string
+     */
+    public function getDenyPermit()
+    {
+    	$deny = array();
+    	$permit = array();
+    	$entries=explode(",", substr($this->getKey('DenyPermit'), 0, -1));
+    	foreach($entries as $entry) {
+    		$entry_parts=explode(":", $entry);
+    		if ($entry_parts[0]=="deny") {
+    			$deny[] = $entry_parts[1];
+    		} else if ($entry_parts[0]=="permit") {
+    			$permit[] = $entry_parts[1];
+    		} else {
+    			throw new PAMIException('Could not parse DenyPermit value: ' . $this->getKey('DenyPermit'));
+    		}
+    	}
+        return array('deny'=>$deny, 'permit'=>$permit);
+    }
+
+    /**
+     * Returns key: 'PermitHosts'.
+     *
+     * @return string
+     */
+    public function getPermitHosts()
+    {
+        return $this->getKey('PermitHosts');
+    }
+
+    /**
+     * Returns key: 'EarlyRTP'.
+     *
+     * @return string
+     */
+    public function getEarlyRTP()
+    {
+        return $this->getKey('EarlyRTP');
+    }
+
+    /**
+     * Returns key: 'DeviceStateAcc'.
+     *
+     * @return string
+     */
+    public function getDeviceStateAcc()
+    {
+        return $this->getKey('DeviceStateAcc');
+    }
+
+    /**
+     * Returns key: 'LastUsedAccessory'.
+     *
+     * @return string
+     */
+    public function getLastUsedAccessory()
+    {
+        return $this->getKey('LastUsedAccessory');
+    }
+
+    /**
+     * Returns key: 'LastDialedNumber'.
+     *
+     * @return string
+     */
+    public function getLastDialedNumber()
+    {
+        return $this->getKey('LastDialedNumber');
+    }
+
+    /**
+     * Returns key: 'DefaultLineInstance'.
+     *
+     * @return integer
+     */
+    public function getDefaultLineInstance()
+    {
+        return intval($this->getKey('DefaultLineInstance'));
+    }
+
+    /**
+     * Returns key: 'CustomBackgroundImage'.
+     *
+     * @return string
+     */
+    public function getCustomBackgroundImage()
+    {
+        return $this->getKey('CustomBackgroundImage');
+    }
+
+    /**
+     * Returns key: 'CustomRingTone'.
+     *
+     * @return string
+     */
+    public function getCustomRingTone()
+    {
+        return $this->getKey('CustomRingTone');
+    }
+
+    /**
+     * Returns key: 'UsePlacedCalls'.
+     *
+     * @return boolean
+     */
+    public function getUsePlacedCalls()
+    {
+        return $this->getBoolKey('UsePlacedCalls');
+    }
+
+    /**
+     * Returns key: 'PendingUpdate'.
+     *
+     * @return boolean
+     */
+    public function getPendingUpdate()
+    {
+        return $this->getBoolKey('PendingUpdate');
+    }
+
+    /**
+     * Returns key: 'PendingDelete'.
+     *
+     * @return boolean
+     */
+    public function getPendingDelete()
+    {
+        return $this->getBoolKey('PendingDelete');
+    }
+
+    /**
+     * Returns key: 'DirectedPickup'.
+     *
+     * @return boolean
+     */
+    public function getDirectedPickup()
+    {
+        return $this->getBoolKey('DirectedPickup');
+    }
+
+    /**
+     * Returns key: 'PickupContext'.
+     *
+     * @return string
+     */
+    public function getPickupContext()
+    {
+        return $this->getKey('PickupContext');
+    }
+
+    /**
+     * Returns key: 'PickupModeAnswer'.
+     *
+     * @return boolean
+     */
+    public function getPickupModeAnswer()
+    {
+        return $this->getBoolKey('PickupModeAnswer');
+    }
+
+    /**
+     * Returns key: 'allowConference'.
+     *
+     * @return boolean
+     */
+    public function getallowConference()
+    {
+        return $this->getBoolKey('allowConference');
+    }
+
+    /**
+     * Returns key: 'confPlayGeneralAnnounce'.
+     *
+     * @return boolean
+     */
+    public function getconfPlayGeneralAnnounce()
+    {
+        return $this->getBoolKey('confPlayGeneralAnnounce');
+    }
+
+    /**
+     * Returns key: 'confPlayPartAnnounce'.
+     *
+     * @return boolean
+     */
+    public function getconfPlayPartAnnounce()
+    {
+        return $this->getBoolKey('confPlayPartAnnounce');
+    }
+
+    /**
+     * Returns key: 'confMuteOnEntry'.
+     *
+     * @return boolean
+     */
+    public function getconfMuteOnEntry()
+    {
+        return $this->getBoolKey('confMuteOnEntry');
+    }
+
+    /**
+     * Returns key: 'confMusicOnHoldClass'.
+     *
+     * @return string
+     */
+    public function getconfMusicOnHoldClass()
+    {
+        return $this->getKey('confMusicOnHoldClass');
+    }
+
+    /**
+     * Returns key: 'confShowConflist'.
+     *
+     * @return boolean
+     */
+    public function getconfShowConflist()
+    {
+        return $this->getBoolKey('confShowConflist');
+    }
+
+    /**
+     * Returns key: 'conflistActive'.
+     *
+     * @return boolean
+     */
+    public function getconflistActive()
+    {
+        return $this->getBoolKey('conflistActive');
+    }
+
+    /**
+     * Returns key: 'TableName'.
+     *
+     * @return string
+     */
+/*
+    public function getTableName()
+    {
+        return $this->getKey('TableName');
+    }
+*/
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowDevicesCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowDevicesCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDevicesCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowHintLineStatesCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowHintLineStatesCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when SCCPShowHintLineStates Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPShowHintLineStates Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowHintLineStatesCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowHintSubscriptionsCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowHintSubscriptionsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when SCCPShowHintSubscriptions Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPShowHintSubscriptions Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowHintSubscriptionsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowLineCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowLineCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLineCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowLineEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowLineEvent.php
@@ -1,0 +1,428 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLineEvent extends EventMessage
+{
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'Description'.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->getKey('Description');
+    }
+
+    /**
+     * Returns key: 'Label'.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->getKey('Label');
+    }
+
+    /**
+     * Returns key: 'ID'.
+     *
+     * @return integer
+     */
+    public function getID()
+    {
+        return intval($this->getKey('ID'));
+    }
+
+    /**
+     * Returns key: 'Pin'.
+     *
+     * @return integer
+     */
+    public function getPin()
+    {
+        return intval($this->getKey('Pin'));
+    }
+
+    /**
+     * Returns key: 'VoiceMailNumber'.
+     *
+     * @return string
+     */
+    public function getVoiceMailNumber()
+    {
+        return $this->getKey('VoiceMailNumber');
+    }
+
+    /**
+     * Returns key: 'TransferToVoicemail'.
+     *
+     * @return string
+     */
+    public function getTransferToVoicemail()
+    {
+        return $this->getKey('TransferToVoicemail');
+    }
+
+    /**
+     * Returns key: 'MeetMeEnabled'.
+     *
+     * @return boolean
+     */
+    public function getMeetMeEnabled()
+    {
+        return $this->getBoolKey('MeetMeEnabled');
+    }
+
+    /**
+     * Returns key: 'MeetMeNumber'.
+     *
+     * @return string
+     */
+    public function getMeetMeNumber()
+    {
+        return $this->getKey('MeetMeNumber');
+    }
+
+    /**
+     * Returns key: 'MeetMeOptions'.
+     *
+     * @return string
+     */
+    public function getMeetMeOptions()
+    {
+        return $this->getKey('MeetMeOptions');
+    }
+
+    /**
+     * Returns key: 'Context'.
+     *
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->getKey('Context');
+    }
+
+    /**
+     * Returns key: 'Language'.
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->getKey('Language');
+    }
+
+    /**
+     * Returns key: 'AccountCode'.
+     *
+     * @return string
+     */
+    public function getAccountCode()
+    {
+        return $this->getKey('AccountCode');
+    }
+
+    /**
+     * Returns key: 'Musicclass'.
+     *
+     * @return string
+     */
+    public function getMusicclass()
+    {
+        return $this->getKey('Musicclass');
+    }
+
+    /**
+     * Returns key: 'AmaFlags'.
+     *
+     * @return integer
+     */
+    public function getAmaFlags()
+    {
+        return intval($this->getKey('AmaFlags'));
+    }
+
+    /**
+     * Returns key: 'CallGroup'.
+     *
+     * @return int[]
+     */
+    public function getCallGroup()
+    {
+    	return array_map('intval', explode(",", $this->getKey('Callgroup')));
+    }
+
+    /**
+     * Returns key: 'PickupGroup'.
+     *
+     * @return int[]
+     */
+    public function getPickupGroup()
+    {
+    	return array_map('intval', explode(",", $this->getKey('Pickupgroup')));
+    }
+
+    /**
+     * Returns key: 'NamedCallGroup'.
+     *
+     * @return string[]
+     */
+    public function getNamedCallGroup()
+    {
+    	return explode(",", $this->getKey('NamedCallGroup'));
+    }
+
+    /**
+     * Returns key: 'NamedPickupGroup'.
+     *
+     * @return string[]
+     */
+    public function getNamedPickupGroup()
+    {
+        return explode(",", $this->getKey('NamedPickupGroup'));
+    }
+
+    /**
+     * Returns key: 'ParkingLot'.
+     *
+     * @return string
+     */
+    public function getParkingLot()
+    {
+        return $this->getKey('ParkingLot');
+    }
+
+    /**
+     * Returns key: 'CallerIDName'.
+     *
+     * @return string
+     */
+    public function getCallerIDName()
+    {
+        return $this->getKey('CallerIDName');
+    }
+
+    /**
+     * Returns key: 'CallerIDNumber'.
+     *
+     * @return string
+     */
+    public function getCallerIDNumber()
+    {
+        return $this->getKey('CallerIDNumber');
+    }
+
+    /**
+     * Returns key: 'IncomingCallsLimit'.
+     *
+     * @return integer
+     */
+    public function getIncomingCallsLimit()
+    {
+        return intval($this->getKey('IncomingCallsLimit'));
+    }
+
+    /**
+     * Returns key: 'ActiveChannelCount'.
+     *
+     * @return integer
+     */
+    public function getActiveChannelCount()
+    {
+        return intval($this->getKey('ActiveChannelCount'));
+    }
+
+    /**
+     * Returns key: 'SecDialtoneDigits'.
+     *
+     * @return integer
+     */
+    public function getSecDialtoneDigits()
+    {
+        return intval($this->getKey('SecDialtoneDigits'));
+    }
+
+    /**
+     * Returns key: 'SecDialtone'.
+     *
+     * @return integer
+     */
+    public function getSecDialtone()
+    {
+    	/* can be either integer or hex -> convert hex to int */
+        return intval($this->getKey('SecDialtone'), 0);
+    }
+
+    /**
+     * Returns key: 'EchoCancellation'.
+     *
+     * @return boolean
+     */
+    public function getEchoCancellation()
+    {
+    	return $this->getBoolKey('EchoCancellation');
+    }
+
+    /**
+     * Returns key: 'SilenceSuppression'.
+     *
+     * @return boolean
+     */
+    public function getSilenceSuppression()
+    {
+    	return $this->getBoolKey('SilenceSuppression');
+    }
+
+    /**
+     * Returns key: 'CanTransfer'.
+     *
+     * @return boolean
+     */
+    public function getCanTransfer()
+    {
+    	return $this->getBoolKey('CanTransfer');
+    }
+
+    /**
+     * Returns key: 'DNDAction'.
+     *
+     * @return string
+     */
+    public function getDNDAction()
+    {
+    	return $this->getKey('DNDAction');
+    }
+
+    /**
+     * Returns key: 'IsRealtimeLine'.
+     *
+     * @return boolean
+     */
+    public function getIsRealtimeLine()
+    {
+    	return $this->getBoolKey('IsRealtimeLine');
+    }
+
+    /**
+     * Returns key: 'PendingDelete'.
+     *
+     * @return boolean
+     */
+    public function getPendingDelete()
+    {
+    	return $this->getBoolKey('PendingDelete');
+    }
+
+    /**
+     * Returns key: 'PendingUpdate'.
+     *
+     * @return boolean
+     */
+    public function getPendingUpdate()
+    {
+    	return $this->getBoolKey('PendingUpdate');
+    }
+
+    /**
+     * Returns key: 'RegistrationExtension'.
+     *
+     * @return string
+     */
+    public function getRegistrationExtension()
+    {
+        return $this->getKey('RegistrationExtension');
+    }
+
+    /**
+     * Returns key: 'RegistrationContext'.
+     *
+     * @return string
+     */
+    public function getRegistrationContext()
+    {
+        return $this->getKey('RegistrationContext');
+    }
+
+    /**
+     * Returns key: 'AdhocNumberAssigned'.
+     *
+     * @return boolean
+     */
+    public function getAdhocNumberAssigned()
+    {
+    	return $this->getBoolKey('AdhocNumberAssigned');
+    }
+
+    /**
+     * Returns key: 'MessageWaitingNew'.
+     *
+     * @return integer
+     */
+    public function getMessageWaitingNew()
+    {
+        return intval($this->getKey('MessageWaitingNew'));
+    }
+
+    /**
+     * Returns key: 'MessageWaitingOld'.
+     *
+     * @return integer
+     */
+    public function getMessageWaitingOld()
+    {
+        return intval($this->getKey('MessageWaitingOld'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowLinesCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowLinesCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLinesCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowMWISubscriptionsCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowMWISubscriptionsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when SCCPShowMWISubscriptions Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPShowMWISubscriptions Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowMWISubscriptionsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowSessionsCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowSessionsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowSessionsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPShowSoftKeySetsCompleteEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPShowSoftKeySetsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when SCCPShowSoftkeySets Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPShowSoftkeySets Completes.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowSoftKeySetsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return int
+     */
+    public function getListItems()
+    {
+        return intval($this->getKey('ListItems'));
+    }
+}

--- a/src/mg/PAMI/Message/Event/SCCPSoftKeySetEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPSoftKeySetEntryEvent.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Event triggered when SCCPSoftKeySetEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when SCCPSoftKeySetEntry arrives.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPSoftKeySetEntryEvent extends EventMessage
+{
+	/**
+	 * Returns key: 'ChannelType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelType()
+	{
+      return $this->getKey('ChannelType');
+	}
+
+	/**
+	 * Returns key: 'ChannelObjectType'.
+	 *
+	 * @return string
+	 */
+	public function getChannelObjectType()
+	{
+      return $this->getKey('ChannelObjectType');
+	}
+
+	/**
+	 * Returns key: 'Set'.
+	 *
+	 * @return string
+	 */
+	public function getSet()
+	{
+      return $this->getKey('Set');
+	}
+
+	/**
+	 * Returns key: 'Mode'.
+	 *
+	 * @return string
+	 */
+	public function getMode()
+	{
+      return $this->getKey('Mode');
+	}
+
+	/**
+	 * Returns key: 'Description'.
+	 *
+	 * @return string
+	 */
+	public function getDescription()
+	{
+      return $this->getKey('Description');
+	}
+
+	/**
+	 * Returns key: 'LblID'.
+	 *
+	 * @return integer
+	 */
+	public function getLblID()
+	{
+      return intval($this->getKey('LblID'));
+	}
+
+	/**
+	 * Returns key: 'Label'.
+	 *
+	 * @return string
+	 */
+	public function getLabel()
+	{
+      return $this->getKey('Label');
+	}
+
+}

--- a/src/mg/PAMI/Message/Event/SCCPVariablesEntryEvent.php
+++ b/src/mg/PAMI/Message/Event/SCCPVariablesEntryEvent.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPVariablesEntryEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ChannelType'.
+     *
+     * @return string
+     */
+    public function getChannelType()
+    {
+        return $this->getKey('ChannelType');
+    }
+
+    /**
+     * Returns key: 'ChannelObjectType'.
+     *
+     * @return string
+     */
+    public function getChannelObjectType()
+    {
+        return $this->getKey('ChannelObjectType');
+    }
+
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getKey('Name');
+    }
+
+    /**
+     * Returns key: 'Value'.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->getKey('Value');
+    }
+}

--- a/src/mg/PAMI/Message/Event/SuccessfulAuthEvent.php
+++ b/src/mg/PAMI/Message/Event/SuccessfulAuthEvent.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SuccessfulAuthEvent extends EventMessage
+{
+    /**
+     * Returns key: 'Privilege'.
+     *
+     * @return string
+     */
+    public function getPrivilege()
+    {
+        return $this->getKey('Privilege');
+    }
+
+    /**
+     * Returns key: 'SequenceNumber'.
+     *
+     * @return int
+     */
+    public function getSequenceNumber()
+    {
+        return $this->getKey('SequenceNumber');
+    }
+
+    /**
+     * Returns key: 'File'.
+     *
+     * @return string
+     */
+    public function getFile()
+    {
+        return $this->getKey('File');
+    }
+
+    /**
+     * Returns key: 'Line'.
+     *
+     * @return int
+     */
+    public function getLine()
+    {
+        return $this->getKey('Line');
+    }
+
+    /**
+     * Returns key: 'Func'.
+     *
+     * @return string
+     */
+    public function getFunc()
+    {
+        return $this->getKey('Func');
+    }
+
+
+    /**
+     * Returns key: 'EventTV'.
+     *
+     * @return string
+     */
+    public function getEventTV()
+    {
+        return $this->getKey('EventTV');
+    }
+
+    /**
+     * Returns key: 'Severity'.
+     *
+     * @return string
+     */
+    public function getSeverity()
+    {
+        return $this->getKey('Severity');
+    }
+    
+    /**
+     * Returns key: 'Service'.
+     *
+     * @return string
+     */
+    public function getService()
+    {
+        return $this->getKey('Service');
+    }
+
+    /**
+     * Returns key: 'EventVersion'.
+     *
+     * @return int
+     */
+    public function getEventVersion()
+    {
+        return $this->getKey('EventVersion');
+    }
+
+    /**
+     * Returns key: 'AccountID'.
+     *
+     * @return string
+     */
+    public function getAccountID()
+    {
+        return $this->getKey('AccountID');
+    }
+
+    /**
+     * Returns key: 'SessionID'.
+     *
+     * @return string
+     */
+    public function getSessionID()
+    {
+        return $this->getKey('SessionID');
+    }
+
+    /**
+     * Returns key: 'LocalAddress'.
+     *
+     * @return string
+     */
+    public function getLocalAddress()
+    {
+        return $this->getKey('LocalAddress');
+    }
+
+    /**
+     * Returns key: 'RemoteAddress'.
+     *
+     * @return string
+     */
+    public function getRemoteAddress()
+    {
+        return $this->getKey('RemoteAddress');
+    }
+
+    /**
+     * Returns key: 'UsingPassword'.
+     *
+     * @return boolean
+     */
+    public function getUsingPassword()
+    {
+        return $this->getBoolKey('UsingPassword');
+    }
+
+    /**
+     * Returns key: 'SessionTV'.
+     *
+     * @return string
+     */
+    public function getSessionTV()
+    {
+        return $this->getKey('SessionTV');
+    }
+}

--- a/src/mg/PAMI/Message/Event/TableEndEvent.php
+++ b/src/mg/PAMI/Message/Event/TableEndEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class TableEndEvent extends EventMessage
+{
+    /**
+     * Returns key: 'TableName'.
+     *
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->getKey('TableName');
+    }
+}

--- a/src/mg/PAMI/Message/Event/TableStartEvent.php
+++ b/src/mg/PAMI/Message/Event/TableStartEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered when an agent logs in.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class TableStartEvent extends EventMessage
+{
+    /**
+     * Returns key: 'TableName'.
+     *
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->getKey('TableName');
+    }
+}

--- a/src/mg/PAMI/Message/IncomingMessage.php
+++ b/src/mg/PAMI/Message/IncomingMessage.php
@@ -28,6 +28,7 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
 /**
  * A generic incoming message.
  *
@@ -97,7 +98,11 @@ abstract class IncomingMessage extends Message
             $name = strtolower(trim($content[0]));
             unset($content[0]);
             $value = isset($content[1]) ? trim(implode(':', $content)) : '';
-            $this->setKey($name, $value);
+			try {
+				$this->setSanitizedKey($name, $value);
+			} catch (PAMIException $e) {
+				throw new PAMIException("Error: '" . $e . "'\n Dump RawContent:\n"  . $this->rawContent ."\n");
+			}
         }
     }
 }

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -28,6 +28,7 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
 /**
  * A generic ami message, in-or-outbound.
  *
@@ -129,6 +130,46 @@ abstract class Message
 	}
 
 	/**
+	 * Sanitize incoming value
+	 *
+	 * @param string $value Key value.
+	 *
+	 * @return typed and sanitized value
+	 */
+	protected function sanitizeInput($value)
+	{
+		if (!isset($value) || $value === NULL || strlen($value) == 0) {
+			return NULL;
+		} else if (is_numeric($value)) {
+			if (filter_var($value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX | FILTER_FLAG_ALLOW_OCTAL)) {
+				return intval($value, 0);
+			} else if (filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_FLAG_ALLOW_FRACTION | FILTER_FLAG_ALLOW_THOUSAND | FILTER_FLAG_ALLOW_SCIENTIFIC)) {
+				return (float)$value;
+			} else {
+				return (double)$value;
+			}
+		} else if (is_string($value)) {
+			if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+				return (boolean)$value;
+			} else if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
+				return (string)$value;
+			} else if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
+				return (string)htmlspecialchars($value, ENT_QUOTES);
+			} else {
+				throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
+			}
+		} else if (is_resource($value)) {
+			// failure ?
+			return $value;
+		} else if (is_object($value)) {
+			// failure ?
+			return (object)$value;
+		} else {
+			throw new PAMIException("Don't know how to convert: '" . $value . "'\n");
+		}
+	}
+
+	/**
 	 * Adds a variable to this message.
 	 *
 	 * @param string $key   Key name (i.e: Action).
@@ -138,8 +179,26 @@ abstract class Message
 	 */
 	protected function setKey($key, $value)
 	{
-	    $key = strtolower((string)$key);
-	    $this->keys[$key] = (string)$value;
+		$key = strtolower((string)$key);
+		$this->keys[$key] = (string)$value;
+	}
+
+	/**
+	 * Adds a variable to this message after sanitizing it first.
+	 *
+	 * @param string $key   Key name (i.e: Action).
+	 * @param string $value Key value.
+	 *
+	 * @return void
+	 */
+	protected function setSanitizedKey($key, $value)
+	{
+		$key = strtolower((string)$key);
+		if ($key === 'actionid') {
+			$this->keys[$key] = (string)$this->sanitizeInput($value);
+		} else {
+			$this->keys[$key] = $this->sanitizeInput($value);
+		}
 	}
 
 	/**
@@ -155,7 +214,22 @@ abstract class Message
 	    if (!isset($this->keys[$key])) {
 		    return null;
 		}
-		return (string)$this->keys[$key];
+		//return (string)$this->keys[$key];
+		return $this->keys[$key];
+	}
+
+	/**
+	 * Returns a key by name as boolean.
+	 *
+	 * @param string $key Key name (i.e: Action).
+	 *
+	 * @return boolean
+	 */
+	public function getBoolKey($key)
+	{
+		$val = $this->getKey($key);
+		$boolval = ( is_string($val) ? filter_var($val, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : (bool) $val );
+		return ( $boolval===null ? false : $boolval );
 	}
 
 	/**

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -158,12 +158,6 @@ abstract class Message
 			} else {
 				throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
 			}
-		} else if (is_resource($value)) {
-			// failure ?
-			return $value;
-		} else if (is_object($value)) {
-			// failure ?
-			return (object)$value;
 		} else {
 			throw new PAMIException("Don't know how to convert: '" . $value . "'\n");
 		}

--- a/src/mg/PAMI/Message/OutgoingMessage.php
+++ b/src/mg/PAMI/Message/OutgoingMessage.php
@@ -28,6 +28,8 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
+
 /**
  * A generic outgoing message.
  *
@@ -41,4 +43,44 @@ namespace PAMI\Message;
  */
 abstract class OutgoingMessage extends Message
 {
+	/**
+	 * String of the Class name to handle the Reponse to this Message
+	 * @var string
+	 */
+	private $_responseHandler;
+
+	/**
+	 * Returns '_responseHandler'.
+	 *
+	 * @return string
+	 */
+	public function getResponseHandler()
+	{
+		if (strlen($this->_responseHandler) > 0) {
+			//throw new PAMIException('Hier:' . $this->_responseHandler);
+			return (string)$this->_responseHandler;
+		} else {
+			return "";
+		}
+	}
+
+	/**
+	 * Set '_responseHandler'.
+	 *
+	 * @return void
+	 * @throws if class cannot be found or strlen($responseHandler) == 0
+	 */
+	public function setResponseHandler($responseHandler)
+	{
+		if (0 == strlen($responseHandler)) {
+			throw new PAMIException('ResponseHandler cannot be empty.');
+		}
+
+		$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+		if (class_exists($className, true)) {
+			$this->_responseHandler = $responseHandler;
+		} else {
+			throw new PAMIException('ResponseHandler could not be found.');
+		}
+	}
 }

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This factory knows which response to return according to a given raw message
+ * from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response\Factory\Impl;
+
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Message\Response\GenericResponse;
+use PAMI\Message\Message;
+
+/**
+ * This factory knows which reponse handler to return according to a given raw message from ami,
+ * the outgoingMessageClass and responseHandler requested by the Action
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ResponseFactoryImpl
+{
+	/**
+	 * This is our factory method.
+	 *
+	 * @param string $message Literal message as received from ami.
+	 * @param string $outgoingMessageClass ClassName
+	 * @param string $responseHandler
+	 *
+	 * @return EventMessage
+	 */
+	public static function createFromRaw($logger, $message, $outgoingMessageClass = false, $responseHandler = false)
+	{
+		if ($outgoingMessageClass != false && $responseHandler == false) {
+			$responseHandler = substr($outgoingMessageClass, 20, -6);
+		}
+		if ($responseHandler != false) {
+			$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+			if (class_exists($className, true)) {
+				if ($logger->isDebugEnabled()) {
+					$logger->debug('ResponseFactoryImpl::createFromRaw, returning class: ' . $className . "\n");
+				}
+				try {
+					return new $className($message);
+				} catch (PAMIException $e) {
+					throw $e;
+				}
+			}
+		}
+		try {
+			return new GenericResponse($message);
+		} catch (PAMIException $e) {
+			throw $e;
+		}
+	}
+
+	/**
+	 * Constructor. Nothing to see here, move along.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+	}
+}

--- a/src/mg/PAMI/Message/Response/GenericResponse.php
+++ b/src/mg/PAMI/Message/Response/GenericResponse.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+//use PAMI\Message\Message;
+//use PAMI\Message\IncomingMessage;
+//use PAMI\Message\Event\EventMessage;
+use PAMI\Message\Response\ResponseMessage;
+//use PAMI\Exception\PAMIException;
+
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class GenericResponse extends ResponseMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+}

--- a/src/mg/PAMI/Message/Response/ResponseMessage.php
+++ b/src/mg/PAMI/Message/Response/ResponseMessage.php
@@ -32,6 +32,7 @@ namespace PAMI\Message\Response;
 use PAMI\Message\Message;
 use PAMI\Message\IncomingMessage;
 use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
 
 /**
  * A generic response message from ami.
@@ -45,19 +46,19 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ResponseMessage extends IncomingMessage
+abstract class ResponseMessage extends IncomingMessage
 {
     /**
      * Child events.
      * @var EventMessage[]
      */
-    private $_events;
+    protected $_events;
 
     /**
      * Is this response completed? (with all its events).
      * @var boolean
      */
-    private $_completed;
+    protected $_completed;
 
     /**
      * Serialize function.

--- a/src/mg/PAMI/Message/Response/SCCPGenericResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPGenericResponse.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
+/**
+ * A generic SCCP response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPGenericResponse extends ResponseMessage
+{
+    /**
+     * Child Tables
+     * @var EventMessage[]
+     */
+    protected $_tables;
+
+    /**
+     * Catch All incoming Events into current Table.
+     * @var Array
+     */
+    private $_temptable;
+
+    /**
+     * Adds an event to this response.
+     *
+     * If we encounter StartTable/EndTable Events we will move the events into the _tables['TableName'] array
+     *
+     * @param EventMessage $event Child event to add.
+     *
+     * @return void
+     */
+    public function addEvent(EventMessage $event)
+    {
+    	// Handle TableStart/TableEnd Differently 
+        if (stristr($event->getName(), 'TableStart') != false) {
+            $this->_temptable['Name'] = $event->getTableName();
+            $this->_temptable['Entries'] = array();
+        } else if (is_array($this->_temptable)) {
+            if (stristr($event->getName(), 'TableEnd') != false) {
+            	if (!is_array($this->_tables)) {
+            		$this->_tables = array();
+            	}
+                $this->_tables[$event->getTableName()] = $this->_temptable;
+                unset($this->_temptable);
+                $this->_temptable = array();
+            } else {
+                $this->_temptable['Entries'][] = $event;
+            }
+        } else {
+            $this->_events[] = $event;
+        }
+        
+        if (
+            stristr($event->getEventList(), 'complete') !== false
+            || stristr($event->getName(), 'complete') !== false
+        ) {
+            $this->_completed = true;
+        }
+    }
+
+    /**
+     * Returns true if this Response Message contains an events tables (TableStart/TableEnd)
+     *
+     * @return boolean
+     */
+    public function hasTable()
+    {
+		if (is_array($this->_tables)) {
+			return true;
+		}
+		return false;
+    }
+
+    /**
+     * Returns all eventtabless for this response.
+     *
+     * @return EventMessage[]
+     */
+    public function getTableNames()
+    {
+    	return array_keys($this->_tables);
+    }
+
+
+    /**
+     * Returns all associated events for this response->tablename.
+     *
+     * @return EventMessage[]
+     */
+    public function getTable($tablename)
+    {
+        if ($this->hasTable() && array_key_exists($tablename, $this->_tables)) {
+        	return $this->_tables[$tablename];
+        }
+		throw new PAMIException("No such table.");        
+    }
+
+    /**
+     * Returns decoded version of the 'JSON' key if present. 
+     *
+     * @return array
+     */
+    public function getJSON()
+    {
+		if (strlen($this->getKey('JSON')) > 0) {
+			if (($json = json_decode($this->getKey('JSON'), true)) != false) {
+				return $json;
+			}
+		}
+		throw new PAMIException("No JSON Key found to return.");
+	}
+
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+        $this->_temptable = array();
+    }
+}

--- a/src/mg/PAMI/Message/Response/SCCPGenericResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPGenericResponse.php
@@ -69,31 +69,42 @@ class SCCPGenericResponse extends ResponseMessage
      */
     public function addEvent(EventMessage $event)
     {
-    	// Handle TableStart/TableEnd Differently 
-        if (stristr($event->getName(), 'TableStart') != false) {
-            $this->_temptable['Name'] = $event->getTableName();
-            $this->_temptable['Entries'] = array();
-        } else if (is_array($this->_temptable)) {
-            if (stristr($event->getName(), 'TableEnd') != false) {
-            	if (!is_array($this->_tables)) {
-            		$this->_tables = array();
-            	}
-                $this->_tables[$event->getTableName()] = $this->_temptable;
-                unset($this->_temptable);
-                $this->_temptable = array();
-            } else {
-                $this->_temptable['Entries'][] = $event;
-            }
-        } else {
-            $this->_events[] = $event;
-        }
-        
-        if (
-            stristr($event->getEventList(), 'complete') !== false
-            || stristr($event->getName(), 'complete') !== false
+    	// not eventlist (start/complete)
+        if (stristr($event->getEventList(), 'start') === false
+            && stristr($event->getEventList(), 'complete') === false
+            && stristr($event->getName(), 'complete') === false
         ) {
-            $this->_completed = true;
+        	$unknownevent = "PAMI\\Message\\Event\\UnknownEvent";
+        	if (!($event instanceof $unknownevent)) {
+				// Handle TableStart/TableEnd Differently 
+				if (stristr($event->getName(), 'TableStart') != false) {
+					$this->_temptable = array();
+					$this->_temptable['Name'] = $event->getTableName();
+					$this->_temptable['Entries'] = array();
+				} else if (stristr($event->getName(), 'TableEnd') != false) {
+					if (!is_array($this->_tables)) {
+						$this->_tables = array();
+					}
+					$this->_tables[$event->getTableName()] = $this->_temptable;
+					unset($this->_temptable);
+				} else if (is_array($this->_temptable)) {
+					$this->_temptable['Entries'][] = $event;
+				} else {
+					// add regular event
+					$this->_events[] = $event;
+				}
+			} else {
+				// add regular event
+				$this->_events[] = $event;
+			}
         }
+        // finish eventlist
+        if (
+            stristr($event->getEventList(), 'complete') != false
+            || stristr($event->getName(), 'complete') != false
+		) {
+            $this->_completed = true;
+		}
     }
 
     /**
@@ -158,6 +169,5 @@ class SCCPGenericResponse extends ResponseMessage
     public function __construct($rawContent)
     {
         parent::__construct($rawContent);
-        $this->_temptable = array();
     }
 }

--- a/src/mg/PAMI/Message/Response/SCCPShowDeviceResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPShowDeviceResponse.php
@@ -1,0 +1,835 @@
+<?php
+/**
+ * An sccp showdevice response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Exception\PAMIException;
+
+/**
+ * An sccp showdevice response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowDeviceResponse extends SCCPGenericResponse
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+	
+	private function _getEventKey($keyname) {
+		return $this->_events[0]->getKey($keyname);
+	}
+
+	private function _getEventBoolKey($keyname) {
+		return $this->_events[0]->getBoolKey($keyname);
+	}
+	
+    /**
+     * Returns key: 'MACAddress'.
+     *
+     * @return string
+     */
+    public function getMACAddress()
+    {
+        return $this->_getEventKey('MACAddress');
+    }
+
+    /**
+     * Returns key: 'DeviceName'.
+     *
+     * @return string
+     */
+    public function getDeviceName()
+    {
+        return $this->getMACAddress();
+    }
+
+    /**
+     * Returns key: 'ProtocolVersion'.
+     *
+     * @return string
+     */
+    public function getProtocolVersion()
+    {
+        return $this->_getEventKey('ProtocolVersion');
+    }
+
+    /**
+     * Returns key: 'ProtocolInUse'.
+     *
+     * @return string
+     */
+    public function getProtocolInUse()
+    {
+        return $this->_getEventKey('ProtocolInUse');
+    }
+
+    /**
+     * Returns key: 'DeviceFeatures'.
+     *
+     * @return string
+     */
+    public function getDeviceFeatures()
+    {
+        return $this->_getEventKey('DeviceFeatures');
+    }
+
+    /**
+     * Returns key: 'Tokenstate'.
+     *
+     * @return string
+     */
+    public function getTokenstate()
+    {
+        return $this->_getEventKey('Tokenstate');
+    }
+
+    /**
+     * Returns key: 'Keepalive'.
+     *
+     * @return integer
+     */
+    public function getKeepalive()
+    {
+        return intval($this->_getEventKey('Keepalive'));
+    }
+
+    /**
+     * Returns key: 'RegistrationState'.
+     *
+     * @return string
+     */
+    public function getRegistrationState()
+    {
+        return $this->_getEventKey('RegistrationState');
+    }
+
+    /**
+     * Returns key: 'State'.
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->_getEventKey('State');
+    }
+
+    /**
+     * Returns key: 'MWILight'.
+     *
+     * @return string
+     */
+    public function getMWILight()
+    {
+        return $this->_getEventKey('MWILight');
+    }
+
+    /**
+     * Returns key: 'MWIHandsetLight'.
+     *
+     * @return boolean
+     */
+    public function getMWIHandsetLight()
+    {
+        return $this->_getEventBoolKey('MWIHandsetLight');
+    }
+
+    /**
+     * Returns key: 'Description'.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->_getEventKey('Description');
+    }
+
+    /**
+     * Returns key: 'ConfigPhoneType'.
+     *
+     * @return string
+     */
+    public function getConfigPhoneType()
+    {
+        return $this->_getEventKey('ConfigPhoneType');
+    }
+
+    /**
+     * Returns key: 'SkinnyPhoneType'.
+     *
+     * @return string
+     */
+    public function getSkinnyPhoneType()
+    {
+        return $this->_getEventKey('SkinnyPhoneType');
+    }
+
+    /**
+     * Returns key: 'SoftkeySupport'.
+     *
+     * @return boolean
+     */
+    public function getSoftkeySupport()
+    {
+        return $this->_getEventBoolKey('SoftkeySupport');
+    }
+
+    /**
+     * Returns key: 'Softkeyset'.
+     *
+     * @return string
+     */
+    public function getSoftkeyset()
+    {
+        return $this->_getEventKey('Softkeyset');
+    }
+
+    /**
+     * Returns key: 'BTemplateSupport'.
+     *
+     * @return boolean
+     */
+    public function getBTemplateSupport()
+    {
+        return $this->_getEventBoolKey('BTemplateSupport');
+    }
+
+    /**
+     * Returns key: 'linesRegistered'.
+     *
+     * @return boolean
+     */
+    public function getLinesRegistered()
+    {
+        return $this->_getEventBoolKey('linesRegistered');
+    }
+
+    /**
+     * Returns key: 'ImageVersion'.
+     *
+     * @return string
+     */
+    public function getImageVersion()
+    {
+        return $this->_getEventKey('ImageVersion');
+    }
+
+    /**
+     * Returns key: 'TimezoneOffset'.
+     *
+     * @return integer
+     */
+    public function getTimezoneOffset()
+    {
+        return intval($this->_getEventKey('TimezoneOffset'));
+    }
+
+    /**
+     * Returns key: 'Capabilities'.
+     *
+     * @return (string|int)[]
+     */
+    public function getCapabilities()
+    {
+    	$ret = array();
+    	$codecs=explode(", ", substr($this->_getEventKey('Capabilities'), 1, -1));
+    	foreach($codecs as $codec) {
+    		$codec_parts=explode(" ", $codec);
+    		$ret[] = array("name" => $codec_parts[0], "value" => substr($codec_parts[1], 1, -1));
+    	}
+        return $ret;
+    }
+
+    /**
+     * Returns key: 'CodecsPreference'.
+     *
+     * @return (string|int)[]
+     */
+    public function getCodecsPreference()
+    {
+    	$ret = array();
+    	$codecs=explode(", ", substr($this->_getEventKey('CodecsPreference'), 1, -1));
+    	foreach($codecs as $codec) {
+    		$codec_parts=explode(" ", $codec);
+    		$ret[] = array("name" => $codec_parts[0], "value" => substr($codec_parts[1], 1, -1));
+    	}
+        return $ret;
+    }
+
+    /**
+     * Returns key: 'AudioTOS'.
+     *
+     * @return integer
+     */
+    public function getAudioTOS()
+    {
+        return intval($this->_getEventKey('AudioTOS'));
+    }
+
+    /**
+     * Returns key: 'AudioCOS'.
+     *
+     * @return integer
+     */
+    public function getAudioCOS()
+    {
+        return intval($this->_getEventKey('AudioCOS'));
+    }
+
+    /**
+     * Returns key: 'VideoTOS'.
+     *
+     * @return integer
+     */
+    public function getVideoTOS()
+    {
+        return intval($this->_getEventKey('VideoTOS'));
+    }
+
+    /**
+     * Returns key: 'VideoCOS'.
+     *
+     * @return integer
+     */
+    public function getVideoCOS()
+    {
+        return intval($this->_getEventKey('VideoCOS'));
+    }
+
+    /**
+     * Returns key: 'DNDFeatureEnabled'.
+     *
+     * @return boolean
+     */
+    public function getDNDFeatureEnabled()
+    {
+        return $this->_getEventBoolKey('DNDFeatureEnabled');
+    }
+
+    /**
+     * Returns key: 'DNDStatus'.
+     *
+     * @return string
+     */
+    public function getDNDStatus()
+    {
+        return $this->_getEventKey('DNDStatus');
+    }
+
+    /**
+     * Returns key: 'DNDAction'.
+     *
+     * @return string
+     */
+    public function getDNDAction()
+    {
+        return $this->_getEventKey('DNDAction');
+    }
+
+    /**
+     * Returns key: 'CanTransfer'.
+     *
+     * @return boolean
+     */
+    public function getCanTransfer()
+    {
+        return $this->_getEventBoolKey('CanTransfer');
+    }
+
+    /**
+     * Returns key: 'CanPark'.
+     *
+     * @return boolean
+     */
+    public function getCanPark()
+    {
+        return $this->_getEventBoolKey('CanPark');
+    }
+
+    /**
+     * Returns key: 'CanCFWDALL'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWDALL()
+    {
+        return $this->_getEventBoolKey('CanCFWDALL');
+    }
+
+    /**
+     * Returns key: 'CanCFWBUSY'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWBUSY()
+    {
+        return $this->_getEventBoolKey('CanCFWBUSY');
+    }
+
+    /**
+     * Returns key: 'CanCFWNOANSWER'.
+     *
+     * @return boolean
+     */
+    public function getCanCFWNOANSWER()
+    {
+        return $this->_getEventBoolKey('CanCFWNOANSWER');
+    }
+
+    /**
+     * Returns key: 'AllowRinginNotification'.
+     *
+     * @return boolean
+     */
+    public function getAllowRinginNotification()
+    {
+        return $this->_getEventBoolKey('AllowRinginNotification');
+    }
+
+    /**
+     * Returns key: 'PrivateSoftkey'.
+     *
+     * @return boolean
+     */
+    public function getPrivateSoftkey()
+    {
+        return $this->_getEventBoolKey('PrivateSoftkey');
+    }
+
+    /**
+     * Returns key: 'DtmfMode'.
+     *
+     * @return string
+     */
+    public function getDtmfMode()
+    {
+        return $this->_getEventKey('DtmfMode');
+    }
+
+    /**
+     * Returns key: 'Nat'.
+     *
+     * @return string
+     */
+    public function getNat()
+    {
+        return $this->_getEventKey('Nat');
+    }
+
+    /**
+     * Returns key: 'Videosupport'.
+     *
+     * @return boolean
+     */
+    public function getVideosupport()
+    {
+        return $this->_getEventBoolKey('Videosupport');
+    }
+
+    /**
+     * Returns key: 'DirectRTP'.
+     *
+     * @return boolean
+     */
+    public function getDirectRTP()
+    {
+        return $this->_getEventBoolKey('DirectRTP');
+    }
+
+    /**
+     * Returns key: 'BindAddress'.
+     *
+     * @return string
+     */
+    public function getBindAddress()
+    {
+        return $this->_getEventKey('BindAddress');
+    }
+
+    /**
+     * Returns key: 'ServerAddress'.
+     *
+     * @return string
+     */
+    public function getServerAddress()
+    {
+        return $this->_getEventKey('ServerAddress');
+    }
+
+    /**
+     * Returns key: 'DenyPermit'.
+     *
+     * @return string
+     */
+    public function getDenyPermit()
+    {
+    	$deny = array();
+    	$permit = array();
+    	$entries=explode(",", substr($this->_getEventKey('DenyPermit'), 0, -1));
+    	foreach($entries as $entry) {
+    		$entry_parts=explode(":", $entry);
+    		if ($entry_parts[0]=="deny") {
+    			$deny[] = $entry_parts[1];
+    		} else if ($entry_parts[0]=="permit") {
+    			$permit[] = $entry_parts[1];
+    		} else {
+    			throw new PAMIException('Could not parse DenyPermit value: ' . $this->_getEventKey('DenyPermit'));
+    		}
+    	}
+        return array('deny'=>$deny, 'permit'=>$permit);
+    }
+
+    /**
+     * Returns key: 'PermitHosts'.
+     *
+     * @return string
+     */
+    public function getPermitHosts()
+    {
+        return $this->_getEventKey('PermitHosts');
+    }
+
+    /**
+     * Returns key: 'EarlyRTP'.
+     *
+     * @return string
+     */
+    public function getEarlyRTP()
+    {
+        return $this->_getEventKey('EarlyRTP');
+    }
+
+    /**
+     * Returns key: 'DeviceStateAcc'.
+     *
+     * @return string
+     */
+    public function getDeviceStateAcc()
+    {
+        return $this->_getEventKey('DeviceStateAcc');
+    }
+
+    /**
+     * Returns key: 'LastUsedAccessory'.
+     *
+     * @return string
+     */
+    public function getLastUsedAccessory()
+    {
+        return $this->_getEventKey('LastUsedAccessory');
+    }
+
+    /**
+     * Returns key: 'LastDialedNumber'.
+     *
+     * @return string
+     */
+    public function getLastDialedNumber()
+    {
+        return $this->_getEventKey('LastDialedNumber');
+    }
+
+    /**
+     * Returns key: 'DefaultLineInstance'.
+     *
+     * @return integer
+     */
+    public function getDefaultLineInstance()
+    {
+        return intval($this->_getEventKey('DefaultLineInstance'));
+    }
+
+    /**
+     * Returns key: 'CustomBackgroundImage'.
+     *
+     * @return string
+     */
+    public function getCustomBackgroundImage()
+    {
+        return $this->_getEventKey('CustomBackgroundImage');
+    }
+
+    /**
+     * Returns key: 'CustomRingTone'.
+     *
+     * @return string
+     */
+    public function getCustomRingTone()
+    {
+        return $this->_getEventKey('CustomRingTone');
+    }
+
+    /**
+     * Returns key: 'UsePlacedCalls'.
+     *
+     * @return boolean
+     */
+    public function getUsePlacedCalls()
+    {
+        return $this->_getEventBoolKey('UsePlacedCalls');
+    }
+
+    /**
+     * Returns key: 'PendingUpdate'.
+     *
+     * @return boolean
+     */
+    public function getPendingUpdate()
+    {
+        return $this->_getEventBoolKey('PendingUpdate');
+    }
+
+    /**
+     * Returns key: 'PendingDelete'.
+     *
+     * @return boolean
+     */
+    public function getPendingDelete()
+    {
+        return $this->_getEventBoolKey('PendingDelete');
+    }
+
+    /**
+     * Returns key: 'DirectedPickup'.
+     *
+     * @return boolean
+     */
+    public function getDirectedPickup()
+    {
+        return $this->_getEventBoolKey('DirectedPickup');
+    }
+
+    /**
+     * Returns key: 'PickupContext'.
+     *
+     * @return string
+     */
+    public function getPickupContext()
+    {
+        return $this->_getEventKey('PickupContext');
+    }
+
+    /**
+     * Returns key: 'PickupModeAnswer'.
+     *
+     * @return boolean
+     */
+    public function getPickupModeAnswer()
+    {
+        return $this->_getEventBoolKey('PickupModeAnswer');
+    }
+
+    /**
+     * Returns key: 'allowConference'.
+     *
+     * @return boolean
+     */
+    public function getallowConference()
+    {
+        return $this->_getEventBoolKey('allowConference');
+    }
+
+    /**
+     * Returns key: 'confPlayGeneralAnnounce'.
+     *
+     * @return boolean
+     */
+    public function getconfPlayGeneralAnnounce()
+    {
+        return $this->_getEventBoolKey('confPlayGeneralAnnounce');
+    }
+
+    /**
+     * Returns key: 'confPlayPartAnnounce'.
+     *
+     * @return boolean
+     */
+    public function getconfPlayPartAnnounce()
+    {
+        return $this->_getEventBoolKey('confPlayPartAnnounce');
+    }
+
+    /**
+     * Returns key: 'confMuteOnEntry'.
+     *
+     * @return boolean
+     */
+    public function getconfMuteOnEntry()
+    {
+        return $this->_getEventBoolKey('confMuteOnEntry');
+    }
+
+    /**
+     * Returns key: 'confMusicOnHoldClass'.
+     *
+     * @return string
+     */
+    public function getconfMusicOnHoldClass()
+    {
+        return $this->_getEventKey('confMusicOnHoldClass');
+    }
+
+    /**
+     * Returns key: 'confShowConflist'.
+     *
+     * @return boolean
+     */
+    public function getconfShowConflist()
+    {
+        return $this->_getEventBoolKey('confShowConflist');
+    }
+
+    /**
+     * Returns key: 'conflistActive'.
+     *
+     * @return boolean
+     */
+    public function getconflistActive()
+    {
+        return $this->_getEventBoolKey('conflistActive');
+    }
+
+    /**
+     * Returns events[] related to ButtonEntries from the tables['Buttons']
+     *
+     * @return events[]
+     */
+	public function getButtons()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('Buttons', $this->_tables)) {
+			$res = $this->_tables['Buttons'];
+		}
+		return $res;
+	}
+
+    /**
+     * Returns events[] related to LineButtons from the tables['LineButtons']
+     *
+     * @return events[]
+     */
+	public function getLineButtons()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('LineButtons', $this->_tables)) {
+			$res = $this->_tables['LineButtons'];
+		}
+		return $res;
+	}
+
+    /**
+     * Returns events[] related to SpeeddialButtons from the tables['SpeeddialButtons']
+     *
+     * @return events[]
+     */
+	public function getSpeeddialButtons()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('SpeeddialButtons', $this->_tables)) {
+			$res = $this->_tables['SpeeddialButtons'];
+		}
+		return $res;
+	}
+
+
+    /**
+     * Returns events[] related to ServiceURLButtons from the tables['ServiceURLs']
+     *
+     * @return events[]
+     */
+	public function getServiceURLButtons()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('ServiceURLButtons', $this->_tables)) {
+			$res = $this->_tables['ServiceURLButtons'];
+		}
+		return $res;
+	}
+
+
+    /**
+     * Returns events[] related to FeatureButtons from the tables['FeatureButtons']
+     *
+     * @return events[]
+     */
+	public function getFeatureButtons()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('FeatureButtons', $this->_tables)) {
+			$res = $this->_tables['FeatureButtons'];
+		}
+		return $res;
+	}
+
+
+    /**
+     * Returns events[] related to Variables from the tables['Variables']
+     *
+     * @return events[]
+     */
+	public function getVariables()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('Variables', $this->_tables)) {
+			$res = $this->_tables['Variables'];
+		}
+		return $res;
+	}
+
+    /**
+     * Returns events[] related to DeviceCallStatistics from the tables['CallStatistics']
+     *
+     * @return events[]
+     */
+	public function getCallStatistics()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('CallStatistics', $this->_tables)) {
+			$res = $this->_tables['CallStatistics'];
+		}
+		return $res;
+	}
+
+}

--- a/src/mg/PAMI/Message/Response/SCCPShowGlobalsResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPShowGlobalsResponse.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * A generic response message from ami.
+ * A sccp show globals response message from ami.
  *
  * PHP Version 5
  *
@@ -32,7 +32,7 @@ namespace PAMI\Message\Response;
 use PAMI\Message\Response\ResponseMessage;
 
 /**
- * A generic response message from ami.
+ * A sccp show globals response message from ami.
  *
  * PHP Version 5
  *

--- a/src/mg/PAMI/Message/Response/SCCPShowGlobalsResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPShowGlobalsResponse.php
@@ -1,0 +1,667 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+use PAMI\Message\Response\ResponseMessage;
+
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowGlobalsResponse extends SCCPGenericResponse
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+    
+    /**
+     * Returns key: 'ConfigFile'.
+     *
+     * @return string
+     */
+    public function getConfigFile()
+    {
+        return $this->getKey('ConfigFile');
+    }
+
+    /**
+     * Returns key: 'PlatformByteOrder'.
+     *
+     * @return string
+     */
+    public function getPlatformByteOrder()
+    {
+        return $this->getKey('PlatformByteOrder');
+    }
+
+    /**
+     * Returns key: 'ServerName'.
+     *
+     * @return string
+     */
+    public function getServerName()
+    {
+        return $this->getKey('ServerName');
+    }
+
+    /**
+     * Returns key: 'BindAddress'.
+     *
+     * @return string
+     */
+    public function getBindAddress()
+    {
+        return $this->getKey('BindAddress');
+    }
+
+    /**
+     * Returns key: 'ExternIP'.
+     *
+     * @return string
+     */
+    public function getExternIP()
+    {
+        return $this->getKey('ExternIP');
+    }
+
+    /**
+     * Returns key: 'Localnet'.
+     *
+     * @return string
+     */
+    public function getLocalnet()
+    {
+        return $this->getKey('Localnet');
+    }
+
+    /**
+     * Returns key: 'DenyPermit'.
+     *
+     * @return string
+     */
+    public function getDenyPermit()
+    {
+        return $this->getKey('DenyPermit');
+    }
+
+    /**
+     * Returns key: 'DirectRTP'.
+     *
+     * @return string
+     */
+    public function getDirectRTP()
+    {
+        return $this->getKey('DirectRTP');
+    }
+
+    /**
+     * Returns key: 'Nat'.
+     *
+     * @return string
+     */
+    public function getNat()
+    {
+        return $this->getKey('Nat');
+    }
+
+    /**
+     * Returns key: 'Keepalive'.
+     *
+     * @return integer
+     */
+    public function getKeepalive()
+    {
+        return intval($this->getKey('Keepalive'));
+    }
+
+    /**
+     * Returns key: 'Debug'.
+     *
+     * @return string
+     */
+    public function getDebug()
+    {
+        return $this->getKey('Debug');
+    }
+
+    /**
+     * Returns key: 'DateFormat'.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return $this->getKey('DateFormat');
+    }
+
+    /**
+     * Returns key: 'FirstDigitTimeout'.
+     *
+     * @return integer
+     */
+    public function getFirstDigitTimeout()
+    {
+        return intval($this->getKey('FirstDigitTimeout'));
+    }
+
+    /**
+     * Returns key: 'DigitTimeout'.
+     *
+     * @return integer
+     */
+    public function getDigitTimeout()
+    {
+        return intval($this->getKey('DigitTimeout'));
+    }
+
+    /**
+     * Returns key: 'DigitTimeoutChar'.
+     *
+     * @return string
+     */
+    public function getDigitTimeoutChar()
+    {
+        return $this->getKey('DigitTimeoutChar');
+    }
+
+    /**
+     * Returns key: 'SCCPTosSignaling'.
+     *
+     * @return integer
+     */
+    public function getSCCPTosSignaling()
+    {
+        return intval($this->getKey('SCCPTosSignaling'));
+    }
+
+    /**
+     * Returns key: 'SCCPCosSignaling'.
+     *
+     * @return integer
+     */
+    public function getSCCPCosSignaling()
+    {
+        return intval($this->getKey('SCCPCosSignaling'));
+    }
+
+    /**
+     * Returns key: 'AUDIOTosRtp'.
+     *
+     * @return integer
+     */
+    public function getAUDIOTosRtp()
+    {
+        return intval($this->getKey('AUDIOTosRtp'));
+    }
+
+    /**
+     * Returns key: 'AUDIOCosRtp'.
+     *
+     * @return integer
+     */
+    public function getAUDIOCosRtp()
+    {
+        return intval($this->getKey('AUDIOCosRtp'));
+    }
+
+    /**
+     * Returns key: 'VIDEOTosVrtp'.
+     *
+     * @return string
+     */
+    public function getVIDEOTosVrtp()
+    {
+        return intval($this->getKey('VIDEOTosVrtp'));
+    }
+
+    /**
+     * Returns key: 'VIDEOCosVrtp'.
+     *
+     * @return integer
+     */
+    public function getVIDEOCosVrtp()
+    {
+        return intval($this->getKey('VIDEOCosVrtp'));
+    }
+
+    /**
+     * Returns key: 'Context'.
+     *
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->getKey('Context');
+    }
+
+    /**
+     * Returns key: 'Language'.
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->getKey('Language');
+    }
+
+    /**
+     * Returns key: 'Accountcode'.
+     *
+     * @return string
+     */
+    public function getAccountcode()
+    {
+        return $this->getKey('Accountcode');
+    }
+
+    /**
+     * Returns key: 'Musicclass'.
+     *
+     * @return string
+     */
+    public function getMusicclass()
+    {
+        return $this->getKey('Musicclass');
+    }
+
+    /**
+     * Returns key: 'AMAFlags'.
+     *
+     * @return string
+     */
+    public function getAMAFlags()
+    {
+        return $this->getKey('AMAFlags');
+    }
+
+    /**
+     * Returns key: 'Callgroup'.
+     *
+     * @return integer[]
+     */
+    public function getCallgroup()
+    {
+        return array_map('intval', explode(",", $this->getKey('Callgroup')));
+    }
+
+    /**
+     * Returns key: 'Pickupgroup'.
+     *
+     * @return integer[]
+     */
+    public function getPickupgroup()
+    {
+        return array_map('intval', explode(",", $this->getKey('Pickupgroup')));
+    }
+
+    /**
+     * Returns key: 'PickupModeAnswer'.
+     *
+     * @return boolean
+     */
+    public function getPickupModeAnswer()
+    {
+        return $this->getBoolKey('PickupModeAnswer');
+    }
+
+    /**
+     * Returns key: 'CodecsPreference'.
+     *
+     * @return (string|int)[]
+     */
+    public function getCodecsPreference()
+    {
+    	$ret = array();
+    	$codecs=explode(", ", substr($this->getKey('CodecsPreference'), 1, -1));
+    	foreach($codecs as $codec) {
+    		$codec_parts=explode(" ", $codec);
+    		$ret[] = array("name" => $codec_parts[0], "value" => substr($codec_parts[1], 1, -1));
+    	}
+        return $ret;
+    }
+
+    /**
+     * Returns key: 'CFWDALL'.
+     *
+     * @return boolean
+     */
+    public function getCFWDALL()
+    {
+    	return $this->getBoolKey('CFWDALL');
+    }
+
+    /**
+     * Returns key: 'CFWBUSY'.
+     *
+     * @return boolean
+     */
+    public function getCFWDBUSY()
+    {
+    	return $this->getBoolKey('CFWDBUSY');
+    }
+
+    /**
+     * Returns key: 'CFWNOANSWER'.
+     *
+     * @return boolean
+     */
+    public function getCFWDNOANSWER()
+    {
+    	return $this->getBoolKey('CFWDNOANSWER');
+    }
+
+    /**
+     * Returns key: 'CallEvents'.
+     *
+     * @return boolean
+     */
+    public function getCallEvents()
+    {
+    	return $this->getBoolKey('CallEvents');
+    }
+
+    /**
+     * Returns key: 'DNDFeatureEnabled'.
+     *
+     * @return boolean
+     */
+    public function getDNDFeatureEnabled()
+    {
+    	return $this->getBoolKey('DNDFeatureEnabled');
+    }
+
+    /**
+     * Returns key: 'Park'.
+     *
+     * @return boolean
+     */
+    public function getPark()
+    {
+    	return $this->getBoolKey('Park');
+    }
+
+    /**
+     * Returns key: 'PrivateSoftkey'.
+     *
+     * @return boolean
+     */
+    public function getPrivateSoftkey()
+    {
+    	return $this->getBoolKey('PrivateSoftkey');
+    }
+
+    /**
+     * Returns key: 'EchoCancel'.
+     *
+     * @return boolean
+     */
+    public function getEchoCancel()
+    {
+    	return $this->getBoolKey('EchoCancel');
+    }
+
+    /**
+     * Returns key: 'SilenceSuppression'.
+     *
+     * @return boolean
+     */
+    public function getSilenceSuppression()
+    {
+    	return $this->getBoolKey('SilenceSuppression');
+    }
+
+    /**
+     * Returns key: 'EarlyRTP'.
+     *
+     * @return string
+     */
+    public function getEarlyRTP()
+    {
+        return $this->getKey('EarlyRTP');
+    }
+
+    /**
+     * Returns key: 'AutoAnswerRingtime'.
+     *
+     * @return string
+     */
+    public function getAutoAnswerRingtime()
+    {
+        return $this->getKey('AutoAnswerRingtime');
+    }
+
+    /**
+     * Returns key: 'AutoAnswerTone'.
+     *
+     * @return string
+     */
+    public function getAutoAnswerTone()
+    {
+        return $this->getKey('AutoAnswerTone');
+    }
+
+    /**
+     * Returns key: 'RemoteHangupTone'.
+     *
+     * @return integer
+     */
+    public function getRemoteHangupTone()
+    {
+        return intval($this->getKey('RemoteHangupTone'));
+    }
+
+    /**
+     * Returns key: 'TransferTone'.
+     *
+     * @return string
+     */
+    public function getTransferTone()
+    {
+        return $this->getKey('TransferTone');
+    }
+
+    /**
+     * Returns key: 'TransferOnHangup'.
+     *
+     * @return boolean
+     */
+    public function getTransferOnHangup()
+    {
+    	return $this->getBoolKey('TransferOnHangup');
+    }
+
+    /**
+     * Returns key: 'CallwaitingTone'.
+     *
+     * @return integer
+     */
+    public function getCallwaitingTone()
+    {
+        return intval($this->getKey('CallwaitingTone'));
+    }
+
+    /**
+     * Returns key: 'CallwaitingInterval'.
+     *
+     * @return integer
+     */
+    public function getCallwaitingInterval()
+    {
+        return intval($this->getKey('CallwaitingInterval'));
+    }
+
+    /**
+     * Returns key: 'RegistrationContext'.
+     *
+     * @return string
+     */
+    public function getRegistrationContext()
+    {
+        return $this->getKey('RegistrationContext');
+    }
+
+    /**
+     * Returns key: 'JitterbufferEnabled'.
+     *
+     * @return boolean
+     */
+    public function getJitterbufferEnabled()
+    {
+    	return $this->getBoolKey('JitterbufferEnabled');
+    }
+
+    /**
+     * Returns key: 'JitterbufferForced'.
+     *
+     * @return boolean
+     */
+    public function getJitterbufferForced()
+    {
+    	return $this->getBoolKey('JitterbufferForced');
+    }
+
+    /**
+     * Returns key: 'JitterbufferMaxSize'.
+     *
+     * @return integer
+     */
+    public function getJitterbufferMaxSize()
+    {
+        return intval($this->getKey('JitterbufferMaxSize'));
+    }
+
+    /**
+     * Returns key: 'JitterbufferResync'.
+     *
+     * @return integer
+     */
+    public function getJitterbufferResync()
+    {
+        return intval($this->getKey('JitterbufferResync'));
+    }
+
+    /**
+     * Returns key: 'JitterbufferImpl'.
+     *
+     * @return string
+     */
+    public function getJitterbufferImpl()
+    {
+        return $this->getKey('JitterbufferImpl');
+    }
+
+    /**
+     * Returns key: 'JitterbufferLog'.
+     *
+     * @return boolean
+     */
+    public function getJitterbufferLog()
+    {
+    	return $this->getBoolKey('JitterbufferLog');
+    }
+
+    /**
+     * Returns key: 'TokenFallBack'.
+     *
+     * @return string
+     */
+    public function getTokenFallBack()
+    {
+        return $this->getKey('TokenFallBack');
+    }
+
+    /**
+     * Returns key: 'TokenBackoffTime'.
+     *
+     * @return integer
+     */
+    public function getTokenBackoffTime()
+    {
+        return intval($this->getKey('TokenBackoffTime'));
+    }
+
+    /**
+     * Returns key: 'HotlineEnabled'.
+     *
+     * @return boolean
+     */
+    public function getHotlineEnabled()
+    {
+    	return $this->getBoolKey('HotlineEnabled');
+    }
+
+    /**
+     * Returns key: 'HotlineContext'.
+     *
+     * @return string
+     */
+    public function getHotlineContext()
+    {
+        return $this->getKey('HotlineContext');
+    }
+
+    /**
+     * Returns key: 'HotlineExten'.
+     *
+     * @return string
+     */
+    public function getHotlineExten()
+    {
+        return $this->getKey('HotlineExten');
+    }
+
+    /**
+     * Returns key: 'ThreadpoolSize'.
+     *
+     * @return string
+     */
+    public function getThreadpoolSize()
+    {
+        return $this->getKey('ThreadpoolSize');
+    }
+
+    
+}

--- a/src/mg/PAMI/Message/Response/SCCPShowLineResponse.php
+++ b/src/mg/PAMI/Message/Response/SCCPShowLineResponse.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * A sccp show line response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+use PAMI\Message\Response\ResponseMessage;
+
+/**
+ * A sccp show line response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class SCCPShowLineResponse extends SCCPGenericResponse
+{
+
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+	
+	private function _getEventKey($keyname) {
+		return $this->_events[0]->getKey($keyname);
+	}
+
+	private function _getEventBoolKey($keyname) {
+		return $this->_events[0]->getBoolKey($keyname);
+	}
+	
+    /**
+     * Returns key: 'Name'.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->_getEventKey('Name');
+    }
+
+    /**
+     * Returns key: 'Description'.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->_getEventKey('Description');
+    }
+
+    /**
+     * Returns key: 'Label'.
+     *
+     * @return string
+     */
+    public function getLabel()
+    {
+        return $this->_getEventKey('Label');
+    }
+
+    /**
+     * Returns key: 'ID'.
+     *
+     * @return integer
+     */
+    public function getID()
+    {
+        return intval($this->_getEventKey('ID'));
+    }
+
+    /**
+     * Returns key: 'Pin'.
+     *
+     * @return integer
+     */
+    public function getPin()
+    {
+        return intval($this->_getEventKey('Pin'));
+    }
+
+    /**
+     * Returns key: 'VoiceMailNumber'.
+     *
+     * @return string
+     */
+    public function getVoiceMailNumber()
+    {
+        return $this->_getEventKey('VoiceMailNumber');
+    }
+
+    /**
+     * Returns key: 'TransferToVoicemail'.
+     *
+     * @return string
+     */
+    public function getTransferToVoicemail()
+    {
+        return $this->_getEventKey('TransferToVoicemail');
+    }
+
+    /**
+     * Returns key: 'MeetMeEnabled'.
+     *
+     * @return boolean
+     */
+    public function getMeetMeEnabled()
+    {
+        return $this->_getEventBoolKey('MeetMeEnabled');
+    }
+
+    /**
+     * Returns key: 'MeetMeNumber'.
+     *
+     * @return string
+     */
+    public function getMeetMeNumber()
+    {
+        return $this->_getEventKey('MeetMeNumber');
+    }
+
+    /**
+     * Returns key: 'MeetMeOptions'.
+     *
+     * @return string
+     */
+    public function getMeetMeOptions()
+    {
+        return $this->_getEventKey('MeetMeOptions');
+    }
+
+    /**
+     * Returns key: 'Context'.
+     *
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->_getEventKey('Context');
+    }
+
+    /**
+     * Returns key: 'Language'.
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->_getEventKey('Language');
+    }
+
+    /**
+     * Returns key: 'AccountCode'.
+     *
+     * @return string
+     */
+    public function getAccountCode()
+    {
+        return $this->_getEventKey('AccountCode');
+    }
+
+    /**
+     * Returns key: 'Musicclass'.
+     *
+     * @return string
+     */
+    public function getMusicclass()
+    {
+        return $this->_getEventKey('Musicclass');
+    }
+
+    /**
+     * Returns key: 'AmaFlags'.
+     *
+     * @return integer
+     */
+    public function getAmaFlags()
+    {
+        return intval($this->_getEventKey('AmaFlags'));
+    }
+
+    /**
+     * Returns key: 'CallGroup'.
+     *
+     * @return int[]
+     */
+    public function getCallGroup()
+    {
+    	return array_map('intval', explode(",", $this->_getEventKey('Callgroup')));
+    }
+
+    /**
+     * Returns key: 'PickupGroup'.
+     *
+     * @return int[]
+     */
+    public function getPickupGroup()
+    {
+    	return array_map('intval', explode(",", $this->_getEventKey('Pickupgroup')));
+    }
+
+    /**
+     * Returns key: 'NamedCallGroup'.
+     *
+     * @return string[]
+     */
+    public function getNamedCallGroup()
+    {
+    	return explode(",", $this->_getEventKey('NamedCallGroup'));
+    }
+
+    /**
+     * Returns key: 'NamedPickupGroup'.
+     *
+     * @return string[]
+     */
+    public function getNamedPickupGroup()
+    {
+        return explode(",", $this->_getEventKey('NamedPickupGroup'));
+    }
+
+    /**
+     * Returns key: 'ParkingLot'.
+     *
+     * @return string
+     */
+    public function getParkingLot()
+    {
+        return $this->_getEventKey('ParkingLot');
+    }
+
+    /**
+     * Returns key: 'CallerIDName'.
+     *
+     * @return string
+     */
+    public function getCallerIDName()
+    {
+        return $this->_getEventKey('CallerIDName');
+    }
+
+    /**
+     * Returns key: 'CallerIDNumber'.
+     *
+     * @return string
+     */
+    public function getCallerIDNumber()
+    {
+        return $this->_getEventKey('CallerIDNumber');
+    }
+
+    /**
+     * Returns key: 'IncomingCallsLimit'.
+     *
+     * @return integer
+     */
+    public function getIncomingCallsLimit()
+    {
+        return intval($this->_getEventKey('IncomingCallsLimit'));
+    }
+
+    /**
+     * Returns key: 'ActiveChannelCount'.
+     *
+     * @return integer
+     */
+    public function getActiveChannelCount()
+    {
+        return intval($this->_getEventKey('ActiveChannelCount'));
+    }
+
+    /**
+     * Returns key: 'SecDialtoneDigits'.
+     *
+     * @return integer
+     */
+    public function getSecDialtoneDigits()
+    {
+        return intval($this->_getEventKey('SecDialtoneDigits'));
+    }
+
+    /**
+     * Returns key: 'SecDialtone'.
+     *
+     * @return integer
+     */
+    public function getSecDialtone()
+    {
+    	/* can be either integer or hex -> convert hex to int */
+        return intval($this->_getEventKey('SecDialtone'), 0);
+    }
+
+    /**
+     * Returns key: 'EchoCancellation'.
+     *
+     * @return boolean
+     */
+    public function getEchoCancellation()
+    {
+    	return $this->_getEventBoolKey('EchoCancellation');
+    }
+
+    /**
+     * Returns key: 'SilenceSuppression'.
+     *
+     * @return boolean
+     */
+    public function getSilenceSuppression()
+    {
+    	return $this->_getEventBoolKey('SilenceSuppression');
+    }
+
+    /**
+     * Returns key: 'CanTransfer'.
+     *
+     * @return boolean
+     */
+    public function getCanTransfer()
+    {
+    	return $this->_getEventBoolKey('CanTransfer');
+    }
+
+    /**
+     * Returns key: 'DNDAction'.
+     *
+     * @return string
+     */
+    public function getDNDAction()
+    {
+    	return $this->_getEventKey('DNDAction');
+    }
+
+    /**
+     * Returns key: 'IsRealtimeLine'.
+     *
+     * @return boolean
+     */
+    public function getIsRealtimeLine()
+    {
+    	return $this->_getEventBoolKey('IsRealtimeLine');
+    }
+
+    /**
+     * Returns key: 'PendingDelete'.
+     *
+     * @return boolean
+     */
+    public function getPendingDelete()
+    {
+    	return $this->_getEventBoolKey('PendingDelete');
+    }
+
+    /**
+     * Returns key: 'PendingUpdate'.
+     *
+     * @return boolean
+     */
+    public function getPendingUpdate()
+    {
+    	return $this->_getEventBoolKey('PendingUpdate');
+    }
+
+    /**
+     * Returns key: 'RegistrationExtension'.
+     *
+     * @return string
+     */
+    public function getRegistrationExtension()
+    {
+        return $this->_getEventKey('RegistrationExtension');
+    }
+
+    /**
+     * Returns key: 'RegistrationContext'.
+     *
+     * @return string
+     */
+    public function getRegistrationContext()
+    {
+        return $this->_getEventKey('RegistrationContext');
+    }
+
+    /**
+     * Returns key: 'AdhocNumberAssigned'.
+     *
+     * @return boolean
+     */
+    public function getAdhocNumberAssigned()
+    {
+    	return $this->_getEventBoolKey('AdhocNumberAssigned');
+    }
+
+    /**
+     * Returns key: 'MessageWaitingNew'.
+     *
+     * @return integer
+     */
+    public function getMessageWaitingNew()
+    {
+        return intval($this->_getEventKey('MessageWaitingNew'));
+    }
+
+    /**
+     * Returns key: 'MessageWaitingOld'.
+     *
+     * @return integer
+     */
+    public function getMessageWaitingOld()
+    {
+        return intval($this->_getEventKey('MessageWaitingOld'));
+    }
+
+	/**
+	 * Returns events[] related to AttachedDevices from the tables['AttachedDevices']
+	 *
+	 * @return events[]
+	 */
+	public function getAttachedDevices()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('AttachedDevices', $this->_tables)) {
+			$res = $this->_tables['AttachedDevices'];
+		}
+		return $res;
+	}
+
+	/**
+	 * Returns events[] related to Mailboxes from the tables['Mailboxes']
+	 *
+	 * @return events[]
+	 */
+	public function getMailboxes()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('Mailboxes', $this->_tables)) {
+			$res = $this->_tables['Mailboxes'];
+		}
+		return $res;
+	}
+
+	/**
+	 * Returns events[] related to Variables from the tables['Variables']
+	 *
+	 * @return events[]
+	 */
+	public function getVariables()
+	{
+		$res = array();
+		if ($this->hasTable() && array_key_exists('Variables', $this->_tables)) {
+			$res = $this->_tables['Variables'];
+		}
+		return $res;
+	}
+}

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -39,6 +39,8 @@ namespace {
     $mockFgets = false;
     $mockFgetsCount = 0;
     $mockFreadReturn = false;
+    $mock_stream_timeout = false;
+    $mockRTimeout = 0;
     $standardAMIStart = array(
    		'Asterisk Call Manager/1.1',
    		'Response: Success',
@@ -91,14 +93,30 @@ namespace PAMI\Client\Impl {
     function stream_socket_shutdown() {
         return true;
     }
-    function stream_set_blocking() {
-        global $mock_stream_set_blocking;
-        if (isset($mock_stream_set_blocking) && $mock_stream_set_blocking === true) {
-            return true;
-        } else {
-            return call_user_func_array('\stream_set_blocking', func_get_args());
-        }
-    }
+	function stream_set_blocking() {
+		global $mock_stream_set_blocking;
+		if (isset($mock_stream_set_blocking) && $mock_stream_set_blocking === true) {
+			return true;
+		} else {
+			return call_user_func_array('\stream_set_blocking', func_get_args());
+		}
+	}
+	function stream_set_timeout() {
+		global $mockRTimeout;
+		$args = func_get_args();
+		$mockRTimeout = $args[1];
+		return true;
+	}
+	function stream_get_meta_data() {
+		global $mockRTimeout;
+		global $mock_stream_timeout;
+		if (isset($mock_stream_timeout) && $mock_stream_timeout === true) {
+			sleep($mockRTimeout);
+			return array('timed_out' => true);
+		} else {
+			return call_user_func_array('\stream_get_meta_data', func_get_args());
+		}
+	}
     function fwrite() {
         global $mockFwrite;
         global $mockFwriteCount;
@@ -160,6 +178,7 @@ namespace PAMI\Client\Impl {
             return call_user_func_array('\fread', func_get_args());
         }
     }
+
     function setFgetsMock(array $readValues, $writeValues)
     {
         global $mockFgets;
@@ -639,11 +658,13 @@ class Test_Client extends \PHPUnit_Framework_TestCase
     {
         global $mock_stream_socket_client;
         global $mock_stream_set_blocking;
+        global $mock_stream_timeout;
         global $mockTime;
         global $standardAMIStart;
         $mockTime = true;
         $mock_stream_socket_client = true;
         $mock_stream_set_blocking = true;
+        $mock_stream_timeout = true;
         $options = array(
             'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
         	'host' => '2.3.4.5',
@@ -651,7 +672,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
         	'port' => 9999,
         	'username' => 'asd',
         	'secret' => 'asd',
-            'connect_timeout' => 10,
+            'connect_timeout' => 3,
         	'read_timeout' => 1
         );
         $write = array(
@@ -663,7 +684,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
         setFgetsMock(array(10, 4), $write);
         $start = \time();
         $client->send(new \PAMI\Message\Action\LoginAction('asd', 'asd'));
-        $this->assertEquals(\time() - $start, 10);
+        $this->assertEquals(\time() - $start, 3);
     }
     /**
      * @test

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -843,7 +843,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
     {
         $now = time();
         $action = new \PAMI\Message\Action\LoginAction('a', 'b');
-        $this->assertEquals($now, $action->getCreatedDate());
+        $this->assertGreaterThanOrEqual($now, $action->getCreatedDate());
         $action->setVariable('variable', 'value');
         $this->assertEquals($action->getVariable('variable'), 'value');
         $this->assertNull($action->getVariable('variable2'));

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -42,866 +42,879 @@ namespace PAMI\Client\Impl {
  */
 class Test_Events extends \PHPUnit_Framework_TestCase
 {
-    private $_properties = array();
+	private $_properties = array();
 
-    public function setUp()
-    {
-        $this->_properties = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
-        );
-    }
-    /**
-     * @test
-     */
-    public function can_report_events()
-    {
-        $eventNames = array(
-            'AsyncAGI', 'AGIExec', 'VarSet', 'Unlink', 'vgsm_sms_rx', 'vgsm_net_state',
-            'vgsm_me_state', 'DTMF', 'Bridge', 'VoicemailUserEntryComplete',
-            'StatusComplete', 'ParkedCallsComplete', 'DBGetResponse',
-            'VoicemailUserEntry', 'Transfer', 'Status', 'ShowDialPlanComplete',
-            'Rename', 'RegistrationsComplete', 'RTPSenderStat', 'RTPReceiverStat',
-            'RTCPSent', 'RTCPReceiverStat', 'RTCPReceived', 'QueueSummaryComplete',
-            'QueueStatusComplete', 'DAHDIShowChannelsComplete', 'QueueSummary',
-            'QueueParams', 'QueueMemberStatus', 'QueueMemberRemoved',
-            'QueueMemberPaused', 'QueueMember', 'QueueMemberAdded', 'PeerlistComplete',
-            'PeerStatus', 'PeerEntry', 'OriginateResponse', 'Newstate', 'Newexten',
-            'Newchannel', 'NewCallerid', 'NewAccountCode', 'MusicOnHold',
-            'MessageWaiting', 'Masquerade', 'ListDialplan', 'Leave', 'Join',
-            'Hold', 'Hangup', 'ExtensionStatus', 'Dial', 'DAHDIShowChannels',
-            'CoreShowChannelsComplete', 'CoreShowChannel', 'ChannelUpdate',
-            'Agents', 'AgentsComplete', 'Agentlogoff', 'Agentlogin', 'AgentConnect',
-            'DongleSMSStatus', 'FullyBooted', 'DongleShowDevicesComplete', 'DongleDeviceEntry',
-            'DongleNewUSSDBase64', 'DongleNewUSSD', 'DongleUSSDStatus', 'DongleNewCUSD',
-            'DongleStatus', 'CEL', 'JabberEvent', 'Registry', 'UserEvent',
-            'ParkedCall', 'UnParkedCall', 'Link'
-        );
-        $eventTranslatedValues = array(
-            'QueueMemberStatus' => array(
-                'Paused' => true
-            ),
-            'QueueMemberPaused' => array(
-                'Paused' => true
-            ),
-            'QueueMember' => array(
-                'Paused' => true
-            ),
-            'QueueMemberAdded' => array(
-                'Paused' => true
-            ),
-        );
-        $eventValues = array(
-            'UserEvent' => array(
-                'Privilege' => 'Privilege',
-                'UniqueID' => 'UniqueID',
-                'UserEvent' => 'UserEvent'
-            ),
-            'Registry' => array(
-                'Channel' => 'Channel',
-                'Domain' => 'Domain',
-                'Status' => 'Status'
-            ),
-            'JabberEvent' => array(
-                'Privilege' => 'Privilege',
-                'Account' => 'Account',
-                'Packet' => 'Packet'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Env',
-                'Channel' => 'Channel',
-                'CommandId' => 'CommandId',
-                'Privilege' => 'Privilege',
-                'SubEvent' => 'SubEvent',
-                'Result' => 'Result'
-            ),
-            'FullyBooted' => array(),
-            'DongleUSSDStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-             ),
-        	'DongleNewUSSDBase64' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-        	'DongleNewCUSD' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleNewUSSD' => array(
-                'Device' => 'Device',
-                'LineCount' => 'LineCount',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleDeviceEntry' => array(
-                'Device' => 'Device',
-                'AudioSetting' => 'AudioSetting',
-                'DataSetting' => 'DataSetting',
-                'IMEISetting' => 'IMEISetting',
-                'IMSISetting' => 'IMSISetting',
-                'ChannelLanguage' => 'ChannelLanguage',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Group' => 'Group',
-                'RXGain' => 'RXGain',
-                'TXGain' => 'TXGain',
-                'U2DIAG' => 'U2DIAG',
-                'UseCallingPres' => 'UseCallingPres',
-                'DefaultCallingPres' => 'DefaultCallingPres',
-                'AutoDeleteSMS' => 'AutoDeleteSMS',
-                'DisableSMS' => 'DisableSMS',
-                'ResetDongle' => 'ResetDongle',
-                'SMSPDU' => 'SMSPDU',
-                'CallWaitingSetting' => 'CallWaitingSetting',
-                'DTMF' => 'DTMF',
-                'MinimalDTMFGap' => 'MinimalDTMFGap',
-                'MinimalDTMFDuration' => 'MinimalDTMFDuration',
-                'MinimalDTMFInterval' => 'MinimalDTMFInterval',
-                'State' => 'State',
-                'AudioState' => 'AudioState',
-                'DataState' => 'DataState',
-                'Voice' => 'Voice',
-                'SMS' => 'SMS',
-                'Manufacturer' => 'Manufacturer',
-                'Model' => 'Model',
-                'Firmware' => 'Firmware',
-                'IMEIState' => 'IMEIState',
-                'IMSIState' => 'IMSIState',
-                'GSMRegistrationStatus' => 'GSMRegistrationStatus',
-                'RSSI' => 'RSSI',
-                'Mode' => 'Mode',
-                'Submode' => 'Submode',
-                'ProviderName' => 'ProviderName',
-                'LocationAreaCode' => 'LocationAreaCode',
-                'CellID' => 'CellID',
-                'SubscriberNumber' => 'SubscriberNumber',
-                'SMSServiceCenter' => 'SMSServiceCenter',
-                'UseUCS2Encoding' => 'UseUCS2Encoding',
-                'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
-                'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
-                'TasksInQueue' => 'TasksInQueue',
-                'CommandsInQueue' => 'CommandsInQueue',
-                'CallWaitingState' => 'CallWaitingState',
-                'CurrentDeviceState' => 'CurrentDeviceState',
-                'DesiredDeviceState' => 'DesiredDeviceState',
-                'CallsChannels' => 'CallsChannels',
-                'Active' => 'Active',
-                'Held' => 'Held',
-                'Dialing' => 'Dialing',
-                'Alerting' => 'Alerting',
-                'Incoming' => 'Incoming',
-                'Waiting' => 'Waiting',
-                'Releasing' => 'Releasing',
-                'Initializing' => 'Initializing'
-        	),
-        	'DongleShowDevicesComplete' => array('ListItems' => 'items'),
-            'DongleSMSStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'DongleStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'AgentConnect' => array(
-                'HoldTime' => 'HoldTime',
-                'Privilege' => 'Privilege',
-                'BridgedChannel' => 'BridgedChannel',
-                'RingTime' => 'RingTime',
-                'Member' => 'Member',
-                'MemberName' => 'MemberName',
-                'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Queue' => 'Queue'
-            ),
-            'Agentlogoff' => array(
-                'Logintime' => 'Logintime',
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-            ),
-            'Agentlogin' => array(
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-            ),
-            'AgentsComplete' => array(),
-            'Agents' => array(
-                'TalkingToChannel' => 'TalkingToChannel',
-                'TalkingTo' => 'TalkingTo',
-                'LoggedInTime' => 'LoggedInTime',
-                'LoggedInChan' => 'LoggedInChan',
-                'Name' => 'Name',
-                'Status' => 'Status',
-                'Agent' => 'Agent'
-            ),
-            'ChannelUpdate' => array(
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'ChannelType' => 'ChannelType',
-        		'UniqueID' => 'UniqueID',
-                'SIPfullcontact' => 'SIPfullcontact',
-                'SIPcallid' => 'SIPcallid'
-            ),
-            'CoreShowChannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'AccountCode' => 'AccountCode',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'CallerIDNum' => 'CallerIDNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Duration' => 'Duration',
-            ),
-            'DAHDIShowChannels' => array(
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Alarm' => 'Alarm',
-                'DND' => 'DND',
-                'SignallingCode' => 'SignallingCode',
-                'Signalling' => 'Signalling'
-            ),
-            'Dial' => array(
-                'Privilege' => 'Privilege',
-                'Destination' => 'Destination',
-                'SubEvent' => 'SubEvent',
-        		'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-        		'DialStatus' => 'DialStatus',
-                'DialString' => 'DialString',
-        		'UniqueID' => 'UniqueID',
-        		'DestUniqueID' => 'DestUniqueID',
-            ),
-            'ExtensionStatus' => array(
-                'Privilege' => 'Privilege',
-                'Status' => 'Status',
-                'Exten' => 'Extension',
-                'Hint' => 'Hint',
-        		'Context' => 'Context',
-            ),
-            'Hangup' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Cause' => 'Cause',
-                'cause-txt' => 'cause-txt'
-            ),
-            'Hold' => array(
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Status' => 'Status',
-                'Channel' => 'Channel',
-            ),
-        	'Join' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-        		'UniqueID' => 'UniqueID',
-                'Position' => 'Position',
-                'Queue' => 'Queue',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'Count' => 'Count',
-            ),
-            'Leave' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Count' => 'Count',
-                'Queue' => 'Queue'
-            ),
-        	'ListDialplan' => array(
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'Registrar' => 'Registrar',
-                'IncludeContext' => 'IncludeContext'
-            ),
-            'Masquerade' => array(
-                'OriginalState' => 'OriginalState',
-                'Original' => 'Original',
-                'CloneState' => 'CloneState',
-                'Clone' => 'Clone',
-                'Privilege' => 'Privilege',
-            ),
-            'MessageWaiting' => array(
-        		'Privilege' => 'Privilege',
-        		'Waiting' => 'Waiting',
-        		'Mailbox' => 'Mailbox',
-            ),
-            'MusicOnHold' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-        		'State' => 'State',
-            ),
-            'NewAccountCode' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'AccountCode' => 'AccountCode',
-                'OldAccountCode' => 'OldAccountCode',
-            ),
-            'NewCallerid' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'CID-CallingPres' => 'CID-CallingPres'
-            ),
-            'Newchannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'AccountCode' => 'AccountCode',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-        	'Newexten' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-        		'UniqueID' => 'UniqueID',
-            ),
-        	'Newstate' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'UniqueID' => 'UniqueID',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName'
-            ),
-            'OriginateResponse' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Response' => 'Response',
-                'ActionID' => 'ActionID',
-                'UniqueID' => 'UniqueID',
-                'Reason' => 'Reason',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-            'PeerEntry' => array(
-                'RealtimeDevice' => 'RealtimeDevice',
-                'Status' => 'Status',
-                'ACL' => 'ACL',
-                'TextSupport' => 'TextSupport',
-                'VideoSupport' => 'VideoSupport',
-                'NatSupport' => 'NatSupport',
-                'Dynamic' => 'Dynamic',
-                'IPPort' => 'IPPort',
-                'IPAddress' => 'IPAddress',
-                'ChanObjectType' => 'ChanObjectType',
-                'ObjectName' => 'ObjectName',
-                'ChannelType' => 'ChannelType',
-            ),
-        	'PeerStatus' => array(
-                'Privilege' => 'Privilege',
-                'ChannelType' => 'ChannelType',
-                'Peer' => 'Peer',
-                'PeerStatus' => 'PeerStatus'
-            ),
-            'QueueMemberRemoved' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberPaused' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege',
-            	'Paused' => 1,
-            ),
-            'QueueMember' => array(
-                'Name' => 'Name',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-            ),
-            'QueueMemberAdded' => array(
-                'MemberName' => 'MemberName',
-                'LastCall' => 'LastCall',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-                'Membership' => 'Membership',
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-        	'QueueParams' => array(
-                'Completed' => '4',
-        		'HoldTime' => '5',
-                'Calls' => '6',
-                'Strategy' => 'Strategy',
-                'Max' => '6',
-                'Queue' => 'Queue',
-                'Weight' => '2',
-                'ServiceLevelPerf' => 'ServiceLevelPerf',
-                'ServiceLevel' => '1',
-                'Abandoned' => '3'
-            ),
-            'QueueSummaryComplete' => array(),
-        	'QueueSummary' => array(
-                'LongestHoldTime' => 'LongestHoldTime',
-                'HoldTime' => 'HoldTime',
-                'Callers' => 'Callers',
-                'Available' => 'Available',
-                'LoggedIn' => 'LoggedIn',
-                'Queue' => 'Queue',
-            ),
-            'QueueStatusComplete' => array(),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'PeerlistComplete' => array('ListItems' => 'ListItems'),
-            'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
-            'RTCPReceived' => array(
-                'DLSR' => 'DLSR',
-                'RTT' => 'RTT',
-                'LastSR' => 'LastSR',
-                'IAJitter' => 'IAJitter',
-                'SequenceNumberCycles' => 'SequenceNumberCycles',
-                'HighestSequence' => 'HighestSequence',
-                'PacketsLost' => 'PacketsLost',
-                'FractionLost' => 'FractionLost',
-                'SenderSSRC' => 'SenderSSRC',
-                'ReceptionReports' => 'ReceptionReports',
-                'PT' => 'PT',
-                'Privilege' => 'Privilege',
-                'From' => 'From',
-            ),
-            'RTCPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'RTCPSent' => array(
-                'DLSR' => 'DLSR',
-                'TheirLastSR' => 'TheirLastSR',
-                'IAJitter' => 'IAJitter',
-                'CumulativeLoss' => 'CumulativeLoss',
-                'FractionLost' => 'FractionLost',
-                'ReportBlock' => 'ReportBlock',
-                'SentOctets' => 'SentOctets',
-                'SentPackets' => 'SentPackets',
-                'SentRTP' => 'SentRTP',
-                'SentNTP' => 'SentNTP',
-                'OurSSRC' => 'OurSSRC',
-                'To' => 'To',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPSenderStat' => array(
-                'SRCount' => 'SRCount',
-                'RTT' => 'RTT',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'SentPackets' => 'SentPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'Rename' => array(
-                'UniqueID' => 'UniqueID',
-                'Oldname' => 'Oldname',
-                'Newname' => 'Newname',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege'
-            ),
-            'ShowDialPlanComplete' => array(
-                'listcontexts' => 'listcontexts',
-                'listpriorities' => 'listpriorities',
-                'listextensions' => 'listextensions',
-                'listitems' => 'listitems',
-                'privilege' => 'privilege'
-            ),
-            'Status' => array(
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Seconds' => 'Seconds',
-                'AccountCode' => 'AccountCode',
-                'Duration' => 'Duration',
-                'CallerIDNum' => 'CallerIDNum',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'UniqueID' => 'UniqueID',
-        		'Privilege' => 'Privilege',
-                'Channel' => 'Channel'
-            ),
-            'Transfer' => array(
-                'TransferContext' => 'TransferContext',
-                'TransferExten' => 'TransferExten',
-                'TargetUniqueid' => 'TargetUniqueid',
-                'UniqueID' => 'UniqueID',
-                'SIP-Callid' => 'SIP-Callid',
-                'TargetChannel' => 'TargetChannel',
-                'Channel' => 'Channel',
-                'TransferType' => 'TransferType',
-                'TransferMethod' => 'TransferMethod',
-                'Privilege' => 'Privilege'
-            ),
-            'VoicemailUserEntryComplete' => array(),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VmContext',
-                'VoicemailBox' => 'VoicemailBox',
-                'Fullname' => 'Fullname',
-                'Email' => 'Email',
-                'Pager' => 'Pager',
-                'ServerEmail' => 'ServerEmail',
-                'MailCommand' => 'MailCommand',
-                'Language' => 'Language',
-                'Timezone' => 'Timezone',
-                'Callback' => 'Callback',
-                'DialOut' => 'DialOut',
-                'UniqueID' => 'UniqueID',
-                'ExitContext' => 'ExitContext',
-                'SayDurationMin' => 'SayDurationMin',
-                'SayEnvelope' => 'SayEnvelope',
-                'SayCID' => 'SayCID',
-                'AttachMessage' => 'AttachMessage',
-                'AttachmentFormat' => 'AttachmentFormat',
-                'DeleteMessage' => 'DeleteMessage',
-                'VolumeGain' => 'VolumeGain',
-                'CanReview' => 'CanReview',
-                'CallOperator' => 'CallOperator',
-                'MaxMessageCount' => 'MaxMessageCount',
-                'MaxMessageLength' => 'MaxMessageLength',
-                'NewMessageCount' => 'NewMessageCount'
-            ),
-            'DBGetResponse' => array(
-                'Family' => 'Family',
-                'Key' => 'Key',
-                'Val' => 'Val'
-            ),
-        	'ParkedCallsComplete' => array(),
-        	'StatusComplete' => array('Items' => 'Items'),
-            'RegistrationsComplete' => array('ListItems' => 'ListItems'),
-            'DTMF' => array(
-            	'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Direction' => 'Direction',
-                'End' => 'End',
-                'Begin' => 'Begin',
-                'Digit' => 'Digit'
-        	),
-            'AGIExec' => array(
-            	'Privilege' => 'Privilege',
-            	'CommandId' => 'CommandId',
-                'SubEvent' => 'SubEvent',
-                'Channel' => 'Channel',
-                'Command' => 'Command',
-                'Result' => 'Result',
-                'ResultCode' => 'ResultCode'
-        	),
-            'VarSet' => array(
-            	'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'Variable' => 'Variable',
-                'Value' => 'Value',
-        	    'UniqueID' => 'UniqueID'
-        	),
-        	'Unlink' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	),
-        	'Bridge' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	    'BridgeState' => 'BridgeStart',
-        	    'BridgeType' => 'BridgeType'
-        	),
-        	'vgsm_sms_rx' => array(
-        		'Privilege' => 'Privilege',
-        		'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
-        	    'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
-        	    'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
-        	    'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
-        	    'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
-        	    'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
-        	    'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
-        	    'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
-        	    'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
-        	    'X-SMS-Message-Type' => 'X-SMS-Message-Type',
-        	    'Content' => 'Content',
-        	    'Date' => 'Date',
-        	    'Content-Transfer-Encoding' => 'ContentEncoding',
-        		'Content-Type' => 'ContentType',
-        	    'MIME-Version' => 'MIME-Version',
-        	    'Subject' => 'Subject',
-        	    'From' => 'From',
-        	    'Received' => 'Received'
-        	),
-        	'vgsm_net_state' => array(
-        		'Privilege' => 'Privilege',
-        		'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
-        	),
-        	'vgsm_me_state' => array(
-        		'Privilege' => 'Privilege',
-        	    'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
-        	    'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
-        	    'X-vGSM-ME-State' => 'X-vGSM-ME-State',
-            ),
-            'CEL' => array(
-                'AMAFlags' => 'AMAFlags',
-                'AccountCode' => 'AccountCode',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'CallerIDani' => 'CallerIDani',
-                'CallerIDdnid' => 'CallerIDdnid',
-                'CallerIDname' => 'CallerIDname',
-                'CallerIDnum' => 'CallerIDnum',
-                'CallerIDrdnis' => 'CallerIDrdnis',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Event' => 'Event',
-                'EventName' => 'EventName',
-                'EventTime' => 'EventTime',
-                'Exten' => 'Exten',
-                'Extra' => 'Extra',
-                'LinkedID' => 'LinkedID',
-                'Peer' => 'Peer',
-                'PeerAccount' => 'PeerAccount',
-                'Privilege' => 'Privilege',
-                'Timestamp' => 'Timestamp',
-                'UniqueID' => 'UniqueID',
-                'Userfield' => 'Userfield',
-            ),
-            'ParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'Timeout' => 'Timeout',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'UnParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'Link' => array(
-                'Privilege' => 'Privilege',
-                'CallerID1' => 'CallerID1',
-                'CallerID2' => 'CallerID2',
-                'UniqueID1' => 'UniqueID1',
-                'UniqueID2' => 'UniqueID2',
-                'Channel1' => 'Channel1',
-                'Channel2' => 'Channel2'
-            ),
-        );
-        $eventGetters = array(
-            'UserEvent' => array(
-                'UserEvent' => 'UserEventName'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Environment'
-            ),
-            'Agents' => array(
-                'LoggedInChan' => 'Channel'
-            ),
-        	'ExtensionStatus' => array(
-                'Exten' => 'Extension'
-            ),
-            'Hangup' => array(
-                'cause-txt' => 'CauseText'
-             ),
-        	'ListDialplan' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'NewCallerid' => array(
-                'CID-CallingPres' => 'CallerIdPres'
-            ),
-            'Newchannel' => array('Exten' => 'Extension'),
-        	'Newexten' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 'Pause'
-            ),
-            'QueueMember' => array(
-                'Name' => 'MemberName'
-            ),
-        	'AGIExec' => array(),
-            'Transfer' => array(
-                'SIP-Callid' => 'SipCallID',
-            ),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VoicemailContext',
-            ),
-            'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
-            'VarSet' => array('Variable' => 'VariableName'),
-        	'StatusComplete' => array('Items' => 'ListItems'),
-            'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
-        	'vgsm_sms_rx' => array(
-        	    'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
-        	    'X-SMS-Reply-Path' => 'ReplyPath',
-        	    'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
-                'X-SMS-SMCC-Number' => 'SMCCNumber',
-        	    'X-SMS-SMCC-TON' => 'SMCCTON',
-        	    'X-SMS-SMCC-NP' => 'SMCCNP',
-        	    'X-SMS-Sender-Number' => 'SenderNumber',
-        	    'X-SMS-Sender-TON' => 'SenderTON',
-        	    'X-SMS-Sender-NP' => 'SenderNP',
-        	    'X-SMS-Message-Type' => 'MessageType',
-                'Content-Transfer-Encoding' => 'ContentEncoding',
-                'Content-Type' => 'ContentType',
-                'MIME-Version' => 'MIMEVersion'
-        	),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
-        	'vgsm_me_state' => array(
-        		'X-vGSM-ME-State-Change-Reason' => 'Reason',
-        	    'X-vGSM-ME-Old-State' => 'OldState',
-        	    'X-vGSM-ME-State' => 'State',
-        	),
-            'ParkedCall' => array('Exten' => 'Extension'),
-            'UnParkedCall' => array('Exten' => 'Extension')
-        );
-        foreach ($eventNames as $eventName) {
-            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
-        }
-    }
+	public function setUp()
+	{
+		$this->_properties = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+		);
+	}
+	/**
+	 * @test
+	 */
+	public function can_report_events()
+	{
+		$eventValues = array(
+			'UserEvent' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'UserEvent' => 'UserEvent'
+			),
+			'Registry' => array(
+				'Channel' => 'Channel',
+				'Domain' => 'Domain',
+				'Status' => 'Status'
+			),
+			'JabberEvent' => array(
+				'Privilege' => 'Privilege',
+				'Account' => 'Account',
+				'Packet' => 'Packet'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Env',
+				'Channel' => 'Channel',
+				'CommandId' => 'CommandId',
+				'Privilege' => 'Privilege',
+				'SubEvent' => 'SubEvent',
+				'Result' => 'Result'
+			),
+			'FullyBooted' => array(),
+			'DongleUSSDStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			 ),
+			'DongleNewUSSDBase64' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewCUSD' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewUSSD' => array(
+				'Device' => 'Device',
+				'LineCount' => 'LineCount',
+				'Privilege' => 'Privilege'
+			),
+			'DongleDeviceEntry' => array(
+				'Device' => 'Device',
+				'AudioSetting' => 'AudioSetting',
+				'DataSetting' => 'DataSetting',
+				'IMEISetting' => 'IMEISetting',
+				'IMSISetting' => 'IMSISetting',
+				'ChannelLanguage' => 'ChannelLanguage',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Group' => 'Group',
+				'RXGain' => 'RXGain',
+				'TXGain' => 'TXGain',
+				'U2DIAG' => 'U2DIAG',
+				'UseCallingPres' => 'UseCallingPres',
+				'DefaultCallingPres' => 'DefaultCallingPres',
+				'AutoDeleteSMS' => 'AutoDeleteSMS',
+				'DisableSMS' => 'DisableSMS',
+				'ResetDongle' => 'ResetDongle',
+				'SMSPDU' => 'SMSPDU',
+				'CallWaitingSetting' => 'CallWaitingSetting',
+				'DTMF' => 'DTMF',
+				'MinimalDTMFGap' => 'MinimalDTMFGap',
+				'MinimalDTMFDuration' => 'MinimalDTMFDuration',
+				'MinimalDTMFInterval' => 'MinimalDTMFInterval',
+				'State' => 'State',
+				'AudioState' => 'AudioState',
+				'DataState' => 'DataState',
+				'Voice' => 'Voice',
+				'SMS' => 'SMS',
+				'Manufacturer' => 'Manufacturer',
+				'Model' => 'Model',
+				'Firmware' => 'Firmware',
+				'IMEIState' => 'IMEIState',
+				'IMSIState' => 'IMSIState',
+				'GSMRegistrationStatus' => 'GSMRegistrationStatus',
+				'RSSI' => 'RSSI',
+				'Mode' => 'Mode',
+				'Submode' => 'Submode',
+				'ProviderName' => 'ProviderName',
+				'LocationAreaCode' => 'LocationAreaCode',
+				'CellID' => 'CellID',
+				'SubscriberNumber' => 'SubscriberNumber',
+				'SMSServiceCenter' => 'SMSServiceCenter',
+				'UseUCS2Encoding' => 'UseUCS2Encoding',
+				'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
+				'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
+				'TasksInQueue' => 'TasksInQueue',
+				'CommandsInQueue' => 'CommandsInQueue',
+				'CallWaitingState' => 'CallWaitingState',
+				'CurrentDeviceState' => 'CurrentDeviceState',
+				'DesiredDeviceState' => 'DesiredDeviceState',
+				'CallsChannels' => 'CallsChannels',
+				'Active' => 'Active',
+				'Held' => 'Held',
+				'Dialing' => 'Dialing',
+				'Alerting' => 'Alerting',
+				'Incoming' => 'Incoming',
+				'Waiting' => 'Waiting',
+				'Releasing' => 'Releasing',
+				'Initializing' => 'Initializing'
+			),
+			'DongleShowDevicesComplete' => array('ListItems' => 'items'),
+			'DongleSMSStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'DongleStatus' => array(
+				'Privilege' => 'Privilege',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'AgentConnect' => array(
+				'HoldTime' => 'HoldTime',
+				'Privilege' => 'Privilege',
+				'BridgedChannel' => 'BridgedChannel',
+				'RingTime' => 'RingTime',
+				'Member' => 'Member',
+				'MemberName' => 'MemberName',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Queue' => 'Queue'
+			),
+			'Agentlogoff' => array(
+				'Logintime' => 'Logintime',
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+			),
+			'Agentlogin' => array(
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+			),
+			'AgentsComplete' => array(),
+			'Agents' => array(
+				'TalkingToChannel' => 'TalkingToChannel',
+				'TalkingTo' => 'TalkingTo',
+				'LoggedInTime' => 'LoggedInTime',
+				'LoggedInChan' => 'LoggedInChan',
+				'Name' => 'Name',
+				'Status' => 'Status',
+				'Agent' => 'Agent'
+			),
+			'ChannelUpdate' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'ChannelType' => 'ChannelType',
+				'UniqueID' => 'UniqueID',
+				'SIPfullcontact' => 'SIPfullcontact',
+				'SIPcallid' => 'SIPcallid'
+			),
+			'CoreShowChannel' => array(
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'AccountCode' => 'AccountCode',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'CallerIDNum' => 'CallerIDNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Duration' => 'Duration',
+			),
+			'DAHDIShowChannels' => array(
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Alarm' => 'Alarm',
+				'DND' => 'DND',
+				'SignallingCode' => 'SignallingCode',
+				'Signalling' => 'Signalling'
+			),
+			'Dial' => array(
+				'Privilege' => 'Privilege',
+				'Destination' => 'Destination',
+				'SubEvent' => 'SubEvent',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'DialStatus' => 'DialStatus',
+				'DialString' => 'DialString',
+				'UniqueID' => 'UniqueID',
+				'DestUniqueID' => 'DestUniqueID',
+			),
+			'ExtensionStatus' => array(
+				'Privilege' => 'Privilege',
+				'Status' => 'Status',
+				'Exten' => 'Extension',
+				'Hint' => 'Hint',
+				'Context' => 'Context',
+			),
+			'Hangup' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Cause' => 'Cause',
+				'cause-txt' => 'cause-txt'
+			),
+			'Hold' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Status' => 'Status',
+				'Channel' => 'Channel',
+			),
+			'Join' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'Position' => 'Position',
+				'Queue' => 'Queue',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'Count' => 'Count',
+			),
+			'Leave' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Count' => 'Count',
+				'Queue' => 'Queue'
+			),
+			'ListDialplan' => array(
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'Registrar' => 'Registrar',
+				'IncludeContext' => 'IncludeContext'
+			),
+			'Masquerade' => array(
+				'OriginalState' => 'OriginalState',
+				'Original' => 'Original',
+				'CloneState' => 'CloneState',
+				'Clone' => 'Clone',
+				'Privilege' => 'Privilege',
+			),
+			'MessageWaiting' => array(
+				'Privilege' => 'Privilege',
+				'Waiting' => 'Waiting',
+				'Mailbox' => 'Mailbox',
+			),
+			'MusicOnHold' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'State' => 'State',
+			),
+			'NewAccountCode' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'AccountCode' => 'AccountCode',
+				'OldAccountCode' => 'OldAccountCode',
+			),
+			'NewCallerid' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'CID-CallingPres' => 'CID-CallingPres'
+			),
+			'Newchannel' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'AccountCode' => 'AccountCode',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'Newexten' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+			),
+			'Newstate' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName'
+			),
+			'OriginateResponse' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Response' => 'Response',
+				'ActionID' => 'ActionID',
+				'UniqueID' => 'UniqueID',
+				'Reason' => 'Reason',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'PeerEntry' => array(
+				'RealtimeDevice' => 'RealtimeDevice',
+				'Status' => 'Status',
+				'ACL' => 'ACL',
+				'TextSupport' => 'TextSupport',
+				'VideoSupport' => 'VideoSupport',
+				'NatSupport' => 'NatSupport',
+				'Dynamic' => 'Dynamic',
+				'IPPort' => 'IPPort',
+				'IPAddress' => 'IPAddress',
+				'ChanObjectType' => 'ChanObjectType',
+				'ObjectName' => 'ObjectName',
+				'ChannelType' => 'ChannelType',
+			),
+			'PeerStatus' => array(
+				'Privilege' => 'Privilege',
+				'ChannelType' => 'ChannelType',
+				'Peer' => 'Peer',
+				'PeerStatus' => 'PeerStatus'
+			),
+			'QueueMemberRemoved' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberPaused' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege',
+				'Paused' => 1,
+			),
+			'QueueMember' => array(
+				'Name' => 'Name',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+			),
+			'QueueMemberAdded' => array(
+				'MemberName' => 'MemberName',
+				'LastCall' => 'LastCall',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueParams' => array(
+				'Completed' => '4',
+				'HoldTime' => '5',
+				'Calls' => '6',
+				'Strategy' => 'Strategy',
+				'Max' => '6',
+				'Queue' => 'Queue',
+				'Weight' => '2',
+				'ServiceLevelPerf' => 'ServiceLevelPerf',
+				'ServiceLevel' => '1',
+				'Abandoned' => '3'
+			),
+			'QueueSummaryComplete' => array(),
+			'QueueSummary' => array(
+				'LongestHoldTime' => 'LongestHoldTime',
+				'HoldTime' => 'HoldTime',
+				'Callers' => 'Callers',
+				'Available' => 'Available',
+				'LoggedIn' => 'LoggedIn',
+				'Queue' => 'Queue',
+			),
+			'QueueStatusComplete' => array(),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'PeerlistComplete' => array('ListItems' => 'ListItems'),
+			'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
+			'RTCPReceived' => array(
+				'DLSR' => 'DLSR',
+				'RTT' => 'RTT',
+				'LastSR' => 'LastSR',
+				'IAJitter' => 'IAJitter',
+				'SequenceNumberCycles' => 'SequenceNumberCycles',
+				'HighestSequence' => 'HighestSequence',
+				'PacketsLost' => 'PacketsLost',
+				'FractionLost' => 'FractionLost',
+				'SenderSSRC' => 'SenderSSRC',
+				'ReceptionReports' => 'ReceptionReports',
+				'PT' => 'PT',
+				'Privilege' => 'Privilege',
+				'From' => 'From',
+			),
+			'RTCPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'RTCPSent' => array(
+				'DLSR' => 'DLSR',
+				'TheirLastSR' => 'TheirLastSR',
+				'IAJitter' => 'IAJitter',
+				'CumulativeLoss' => 'CumulativeLoss',
+				'FractionLost' => 'FractionLost',
+				'ReportBlock' => 'ReportBlock',
+				'SentOctets' => 'SentOctets',
+				'SentPackets' => 'SentPackets',
+				'SentRTP' => 'SentRTP',
+				'SentNTP' => 'SentNTP',
+				'OurSSRC' => 'OurSSRC',
+				'To' => 'To',
+				'Privilege' => 'Privilege'
+			),
+			'RTPSenderStat' => array(
+				'SRCount' => 'SRCount',
+				'RTT' => 'RTT',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'SentPackets' => 'SentPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege'
+			),
+			'RTPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'Rename' => array(
+				'UniqueID' => 'UniqueID',
+				'Oldname' => 'Oldname',
+				'Newname' => 'Newname',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege'
+			),
+			'ShowDialPlanComplete' => array(
+				'listcontexts' => 'listcontexts',
+				'listpriorities' => 'listpriorities',
+				'listextensions' => 'listextensions',
+				'listitems' => 'listitems',
+				'privilege' => 'privilege'
+			),
+			'Status' => array(
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Seconds' => 'Seconds',
+				'AccountCode' => 'AccountCode',
+				'Duration' => 'Duration',
+				'CallerIDNum' => 'CallerIDNum',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel'
+			),
+			'Transfer' => array(
+				'TransferContext' => 'TransferContext',
+				'TransferExten' => 'TransferExten',
+				'TargetUniqueid' => 'TargetUniqueid',
+				'UniqueID' => 'UniqueID',
+				'SIP-Callid' => 'SIP-Callid',
+				'TargetChannel' => 'TargetChannel',
+				'Channel' => 'Channel',
+				'TransferType' => 'TransferType',
+				'TransferMethod' => 'TransferMethod',
+				'Privilege' => 'Privilege'
+			),
+			'VoicemailUserEntryComplete' => array(),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VmContext',
+				'VoicemailBox' => 'VoicemailBox',
+				'Fullname' => 'Fullname',
+				'Email' => 'Email',
+				'Pager' => 'Pager',
+				'ServerEmail' => 'ServerEmail',
+				'MailCommand' => 'MailCommand',
+				'Language' => 'Language',
+				'Timezone' => 'Timezone',
+				'Callback' => 'Callback',
+				'DialOut' => 'DialOut',
+				'UniqueID' => 'UniqueID',
+				'ExitContext' => 'ExitContext',
+				'SayDurationMin' => 'SayDurationMin',
+				'SayEnvelope' => 'SayEnvelope',
+				'SayCID' => 'SayCID',
+				'AttachMessage' => 'AttachMessage',
+				'AttachmentFormat' => 'AttachmentFormat',
+				'DeleteMessage' => 'DeleteMessage',
+				'VolumeGain' => 'VolumeGain',
+				'CanReview' => 'CanReview',
+				'CallOperator' => 'CallOperator',
+				'MaxMessageCount' => 'MaxMessageCount',
+				'MaxMessageLength' => 'MaxMessageLength',
+				'NewMessageCount' => 'NewMessageCount'
+			),
+			'DBGetResponse' => array(
+				'Family' => 'Family',
+				'Key' => 'Key',
+				'Val' => 'Val'
+			),
+			'ParkedCallsComplete' => array(),
+			'StatusComplete' => array('Items' => 'Items'),
+			'RegistrationsComplete' => array('ListItems' => 'ListItems'),
+			'DTMF' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Direction' => 'Direction',
+				'End' => 'End',
+				'Begin' => 'Begin',
+				'Digit' => 'Digit'
+			),
+			'AGIExec' => array(
+				'Privilege' => 'Privilege',
+				'CommandId' => 'CommandId',
+				'SubEvent' => 'SubEvent',
+				'Channel' => 'Channel',
+				'Command' => 'Command',
+				'Result' => 'Result',
+				'ResultCode' => 'ResultCode'
+			),
+			'VarSet' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'Variable' => 'Variable',
+				'Value' => 'Value',
+				'UniqueID' => 'UniqueID'
+			),
+			'Unlink' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+			),
+			'Bridge' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+				'BridgeState' => 'BridgeStart',
+				'BridgeType' => 'BridgeType'
+			),
+			'vgsm_sms_rx' => array(
+				'Privilege' => 'Privilege',
+				'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
+				'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
+				'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
+				'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
+				'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
+				'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
+				'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
+				'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
+				'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
+				'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
+				'X-SMS-Message-Type' => 'X-SMS-Message-Type',
+				'Content' => 'Content',
+				'Date' => 'Date',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIME-Version',
+				'Subject' => 'Subject',
+				'From' => 'From',
+				'Received' => 'Received'
+			),
+			'vgsm_net_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
+			),
+			'vgsm_me_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
+				'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
+				'X-vGSM-ME-State' => 'X-vGSM-ME-State',
+			),
+			'CEL' => array(
+				'AMAFlags' => 'AMAFlags',
+				'AccountCode' => 'AccountCode',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'CallerIDani' => 'CallerIDani',
+				'CallerIDdnid' => 'CallerIDdnid',
+				'CallerIDname' => 'CallerIDname',
+				'CallerIDnum' => 'CallerIDnum',
+				'CallerIDrdnis' => 'CallerIDrdnis',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Event' => 'Event',
+				'EventName' => 'EventName',
+				'EventTime' => 'EventTime',
+				'Exten' => 'Exten',
+				'Extra' => 'Extra',
+				'LinkedID' => 'LinkedID',
+				'Peer' => 'Peer',
+				'PeerAccount' => 'PeerAccount',
+				'Privilege' => 'Privilege',
+				'Timestamp' => 'Timestamp',
+				'UniqueID' => 'UniqueID',
+				'Userfield' => 'Userfield',
+			),
+			'ParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'Timeout' => 'Timeout',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'UnParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'Link' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2'
+			),
+			'SuccessfulAuth' => array(
+				'Privilege' => 'security,all',
+				'EventTV' => '2015-04-04T21:04:12.937+0200',
+				'Severity' => 'Informational',
+				'Service' => 'AMI',
+				'EventVersion' => '1',
+				'AccountID' => 'admin',
+				'SessionID' => '0x7fa9d41418c8',
+				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
+				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
+				'UsingPassword' => '0',
+				'SessionTV' => '2015-04-04T21:04:12.937+0200',
+			),
+			'RequestBadFormat' => array(
+				'Privilege' => 'security,all',
+				'EventTV' => '2015-04-04T21:04:12.937+0200',
+				'Severity' => 'Informational',
+				'Service' => 'AMI',
+				'EventVersion' => '1',
+				'AccountID' => 'admin',
+				'SessionID' => '0x7fa9d41418c8',
+				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
+				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
+				'UsingPassword' => '0',
+				'SessionTV' => '2015-04-04T21:04:12.937+0200',
+			),
+		);
+		$eventTranslatedValues = array(
+			'QueueMemberStatus' => array(
+				'Paused' => true
+			),
+			'QueueMemberPaused' => array(
+				'Paused' => true
+			),
+			'QueueMember' => array(
+				'Paused' => true
+			),
+			'QueueMemberAdded' => array(
+				'Paused' => true
+			),
+			'SuccessfulAuth' => array(
+				'EventVersion' => 1,
+				'UsingPassword' => false,
+			),
+			'RequestBadFormat' => array(
+				'EventVersion' => 1,
+				'UsingPassword' => false,
+			),
+		);
+		$eventGetters = array(
+			'UserEvent' => array(
+				'UserEvent' => 'UserEventName'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Environment'
+			),
+			'Agents' => array(
+				'LoggedInChan' => 'Channel'
+			),
+			'ExtensionStatus' => array(
+				'Exten' => 'Extension'
+			),
+			'Hangup' => array(
+				'cause-txt' => 'CauseText'
+			 ),
+			'ListDialplan' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'NewCallerid' => array(
+				'CID-CallingPres' => 'CallerIdPres'
+			),
+			'Newchannel' => array('Exten' => 'Extension'),
+			'Newexten' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 'Pause'
+			),
+			'QueueMember' => array(
+				'Name' => 'MemberName'
+			),
+			'AGIExec' => array(),
+			'Transfer' => array(
+				'SIP-Callid' => 'SipCallID',
+			),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VoicemailContext',
+			),
+			'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
+			'VarSet' => array('Variable' => 'VariableName'),
+			'StatusComplete' => array('Items' => 'ListItems'),
+			'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
+			'vgsm_sms_rx' => array(
+				'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
+				'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
+				'X-SMS-Reply-Path' => 'ReplyPath',
+				'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
+				'X-SMS-SMCC-Number' => 'SMCCNumber',
+				'X-SMS-SMCC-TON' => 'SMCCTON',
+				'X-SMS-SMCC-NP' => 'SMCCNP',
+				'X-SMS-Sender-Number' => 'SenderNumber',
+				'X-SMS-Sender-TON' => 'SenderTON',
+				'X-SMS-Sender-NP' => 'SenderNP',
+				'X-SMS-Message-Type' => 'MessageType',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIMEVersion'
+			),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
+			'vgsm_me_state' => array(
+				'X-vGSM-ME-State-Change-Reason' => 'Reason',
+				'X-vGSM-ME-Old-State' => 'OldState',
+				'X-vGSM-ME-State' => 'State',
+			),
+			'ParkedCall' => array('Exten' => 'Extension'),
+			'UnParkedCall' => array('Exten' => 'Extension')
+		);
+		foreach (array_keys($eventValues) as $eventName) {
+			$this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+		}
+	}
 
-    private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
-    {
-        global $mock_stream_socket_client;
-        global $mock_stream_set_blocking;
-        global $mockTime;
-        global $standardAMIStart;
-        $eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
-        $mockTime = true;
-        $mock_stream_socket_client = true;
-        $mock_stream_set_blocking = true;
-        $options = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
-        	'host' => '2.3.4.5',
-            'scheme' => 'tcp://',
-        	'port' => 9999,
-        	'username' => 'asd',
-        	'secret' => 'asd',
-            'connect_timeout' => 10,
-        	'read_timeout' => 10
-        );
-        $write = array(
-        	"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
-        );
-        setFgetsMock($standardAMIStart, $write);
-        $client = new \PAMI\Client\Impl\ClientImpl($options);
-        $client->registerEventListener(new SomeListenerClass);
-	    $client->open();
-	    $message = array();
-	    $message[] = 'Event: ' . $eventName;
-	    foreach ($values as $key => $value) {
-	        $message[] = $key . ': ' . $value;
-	    }
-	    $message[] = '';
-	    setFgetsMock($message, $message);
-	    for($i = 0; $i < count($message); $i++) {
-	        $client->process();
-	    }
-	    $event = SomeListenerClass::$event;
-        $this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
-        foreach ($values as $key => $value) {
-            if (isset($getters[$eventName][$key])) {
-                $methodName = 'get' . $getters[$eventName][$key];
-            } else {
-                $methodName = 'get' . $key;
-            }
-            if (isset($translatedValues[$eventName][$key])) {
-                $value = $translatedValues[$eventName][$key];
-            }
-            $this->assertEquals($event->$methodName(), $value);
-        }
-    }
+	private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
+	{
+		global $mock_stream_socket_client;
+		global $mock_stream_set_blocking;
+		global $mockTime;
+		global $standardAMIStart;
+		$eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
+		$mockTime = true;
+		$mock_stream_socket_client = true;
+		$mock_stream_set_blocking = true;
+		$options = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
+			'host' => '2.3.4.5',
+			'scheme' => 'tcp://',
+			'port' => 9999,
+			'username' => 'asd',
+			'secret' => 'asd',
+			'connect_timeout' => 10,
+			'read_timeout' => 10
+		);
+		$write = array(
+			"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
+		);
+		setFgetsMock($standardAMIStart, $write);
+		$client = new \PAMI\Client\Impl\ClientImpl($options);
+		$client->registerEventListener(new SomeListenerClass);
+		$client->open();
+		$message = array();
+		$message[] = 'Event: ' . $eventName;
+		foreach ($values as $key => $value) {
+			$message[] = $key . ': ' . $value;
+		}
+		$message[] = '';
+		setFgetsMock($message, $message);
+		for($i = 0; $i < count($message); $i++) {
+			$client->process();
+		}
+		$event = SomeListenerClass::$event;
+		$this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
+		foreach ($values as $key => $value) {
+			if (isset($getters[$eventName][$key])) {
+				$methodName = 'get' . $getters[$eventName][$key];
+			} else {
+				$methodName = 'get' . $key;
+			}
+			if (isset($translatedValues[$eventName][$key])) {
+				$value = $translatedValues[$eventName][$key];
+			}
+			$this->assertEquals($event->$methodName(), $value, "Event: '$eventName'->'$methodName' to retrieve Key: '$key', returned Value: '". var_dump($event->$methodName()) ."' instead of expected: '" . var_dump($value) . "'");
+		}
+	}
 }
 }

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -742,19 +742,6 @@ class Test_Events extends \PHPUnit_Framework_TestCase
 				'Channel1' => 'Channel1',
 				'Channel2' => 'Channel2'
 			),
-			'SuccessfulAuth' => array(
-				'Privilege' => 'security,all',
-				'EventTV' => '2015-04-04T21:04:12.937+0200',
-				'Severity' => 'Informational',
-				'Service' => 'AMI',
-				'EventVersion' => '1',
-				'AccountID' => 'admin',
-				'SessionID' => '0x7fa9d41418c8',
-				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
-				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
-				'UsingPassword' => '0',
-				'SessionTV' => '2015-04-04T21:04:12.937+0200',
-			),
 			'RequestBadFormat' => array(
 				'Privilege' => 'security,all',
 				'EventTV' => '2015-04-04T21:04:12.937+0200',
@@ -781,10 +768,6 @@ class Test_Events extends \PHPUnit_Framework_TestCase
 			),
 			'QueueMemberAdded' => array(
 				'Paused' => true
-			),
-			'SuccessfulAuth' => array(
-				'EventVersion' => 1,
-				'UsingPassword' => false,
 			),
 			'RequestBadFormat' => array(
 				'EventVersion' => 1,

--- a/test/factories/Test_Factories.php
+++ b/test/factories/Test_Factories.php
@@ -44,6 +44,7 @@ namespace PAMI\Client\Impl {
 	class Test_ResponseFactory extends \PHPUnit_Framework_TestCase
 	{
 		private $_properties = array();
+		private $_logger;
 
 		public function setUp()
 		{
@@ -53,7 +54,6 @@ namespace PAMI\Client\Impl {
 			if (isset($_properties['log4php.properties'])) {
 				\Logger::configure($_properties['log4php.properties']);
 			}
-			
 			$this->_logger = \Logger::getLogger('ResponseFactory');
 		}
 

--- a/test/factories/Test_Factories.php
+++ b/test/factories/Test_Factories.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This class will test the ami response factory
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage ReponseFactory
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+//namespace PAMI\Message\Response\Factory\Impl {
+namespace PAMI\Client\Impl {
+	/**
+	 * This class will test the response factory
+	 *
+	 * PHP Version 5
+	 *
+	 * @category   Pami
+	 * @package    Test
+	 * @subpackage Response Factory
+	 * @author     Diederik de Groot <ddegroot@users.sf.net>
+	 * @license    http://marcelog.github.com/ Apache License 2.0
+	 * @link       http://marcelog.github.com/
+	 */
+	class Test_ResponseFactory extends \PHPUnit_Framework_TestCase
+	{
+		private $_properties = array();
+
+		public function setUp()
+		{
+			$this->_properties = array(
+				'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+			);
+			if (isset($_properties['log4php.properties'])) {
+				\Logger::configure($_properties['log4php.properties']);
+			}
+			
+			$this->_logger = \Logger::getLogger('ResponseFactory');
+		}
+
+		/**
+		 * @test
+		 * 
+		 * we might want to revise this behaviour, ResponseMessage ie. GenericReponse should catch this and throw an exception
+		 */
+		public function can_create_genericresponse_with_empty_message()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('', false, false);
+			
+			// we might want to revise this behaviour, GenericReponse should capture this i think and throw
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_using_responsefactory()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, false);
+			$this->assertTrue ($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_responsehandler()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, 'Generic');
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$actionClass = "\\PAMI\\Message\\Action\\LoginAction";
+			$action = new $actionClass('test', 'boo');
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', $action, false);
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+	     * @expectedException PAMI\Exception\PAMIException
+		 */
+		public function can_get_exception_using_responsefactory_with_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\BooResponse";
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, "boo");
+			$this->assertFalse($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+	}
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -15,6 +15,9 @@
     <testsuite name="Client">
       <directory suffix=".php">client</directory>
     </testsuite>
+    <testsuite name="Factories">
+      <directory suffix=".php">factories</directory>
+    </testsuite>
     <testsuite name="Autoloader">
       <directory suffix=".php">autoloader</directory>
     </testsuite>

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -24,5 +24,11 @@
     <testsuite name="Events">
       <directory suffix=".php">events</directory>
     </testsuite>
+    <testsuite name="SCCPActions">
+      <directory suffix=".php">sccp_actions</directory>
+    </testsuite>
+    <testsuite name="SCCPEvents">
+      <directory suffix=".php">sccp_events</directory>
+    </testsuite>
   </testsuites>
 </phpunit>

--- a/test/sccp_actions/SCCP_Test_Actions.php
+++ b/test/sccp_actions/SCCP_Test_Actions.php
@@ -1,0 +1,1511 @@
+<?php
+/**
+ * This class will test some actions.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage Action
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace PAMI\Client\Impl {
+
+/**
+ * This class will test some actions.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage Action
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @link       http://marcelog.github.com/
+ */
+class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
+{
+	private $_properties = array();
+
+	public function setUp()
+	{
+		global $mockTime;
+		$this->_properties = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+		);
+		$mockTime = true;
+	}
+
+	/** 
+	 * Test Helper
+	 */
+	private function _start_action(array $write, \PAMI\Message\Action\ActionMessage $action, $response, $mocktime=true)
+	{
+		global $mock_stream_socket_client;
+		global $mock_stream_set_blocking;
+		global $mockTime;
+		global $standardAMIStart;
+		$mock_time = $mocktime;
+		$mock_stream_socket_client = true;
+		$mock_stream_set_blocking = true;
+		$options = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
+			'host' => '2.3.4.5',
+			'scheme' => 'tcp://',
+			'port' => 9999,
+			'username' => 'asd',
+			'secret' => 'asd',
+			'connect_timeout' => 10,
+			'read_timeout' => 100									/* readtimout still needs work, 100 needed for large responses */
+		);
+		$writeLogin = array(
+			"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
+		);
+		setFgetsMock($standardAMIStart, $writeLogin);
+		$client = new \PAMI\Client\Impl\ClientImpl($options);
+		$client->registerEventListener(new SomeListenerClass);
+		$client->open();
+		setFgetsMock($response, $write);
+		$result = $client->send($action);
+		return $result;
+	}
+
+	/** 
+	 * Test Helper
+	 */
+	private function _start(array $write, \PAMI\Message\Action\ActionMessage $action)
+	{
+		if ($action instanceof \PAMI\Message\Action\DBGetAction) {
+			$response = array(
+				'Response: Success',
+				'EventList: start',
+				'ActionID: 1432.123',
+				'',
+				'Event: DBGetResponse',
+				'ActionID: 1432.123',
+				''
+			);
+		} else if ($action instanceof \PAMI\Message\Action\SCCPConfigMetaDataAction) {
+			$response = array(
+				'Response: Success',
+				'JSON: {"Name":"Chan-sccp-b","Branch":"RC2","Version":"4.2.0","Revision":"5995M","ConfigRevision":"5988","ConfigureEnabled": ["park","pickup","realtime","conferenence","dirtrfr","feature_monitor","functions","manager_events","devicestate","devstate_feature","dynamic_speeddial","dynamic_speeddial_cid","experimental","debug"],"Segments":["general","device","line","softkey"]}',
+				'ActionID: 1432.123',
+				'',
+			);
+		} else {
+			$response = array(
+				'Response: Success',
+				'ActionID: 1432.123',
+				''
+			);
+		}
+		$result = $this->_start_action($write, $action, $response, false);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		return $result;
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPConfigMetaData()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			''
+		)));
+
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction();
+		$result = $this->_start($write, $action);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPConfigMetaData_segment_general()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			'segment: general',
+			''
+		)));
+		$response = array(
+			'Response: Success',
+			'JSON: {"Name":"Chan-sccp-b","Branch":"RC2","Version":"4.2.0","Revision":"5995M","ConfigRevision":"5988","ConfigureEnabled": ["park","pickup","realtime","conferenence","dirtrfr","feature_monitor","functions","manager_events","devicestate","devstate_feature","dynamic_speeddial","dynamic_speeddial_cid","experimental","debug"],"Segments":["general","device","line","softkey"]}',
+			'ActionID: 1432.123',
+			'',
+		);
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction('general');
+		$result = $this->_start($write, $action, $response);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPConfigMetaData_segment_device()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			'segment: device',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction('device');
+		$result = $this->_start($write, $action);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPConfigMetaData_segment_line()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			'segment: line',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction('line');
+		$result = $this->_start($write, $action);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPConfigMetaData_segment_softkey()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			'segment: softkey',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction('softkey');
+		$result = $this->_start($write, $action);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\ResponseMessage);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+	/**
+	 * @test
+     * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_get_SCCPConfigMetaData_brokenjson()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConfigMetaData',
+			'actionid: 1432.123',
+			'segment: softkey',
+			''
+		)));
+		$response = array(
+			'Response: Success',
+			'JSON: {{{[["Name":"Chan-sccp-b"' ,
+			'ActionID: 1432.123',
+			'',
+		);
+		$action = new \PAMI\Message\Action\SCCPConfigMetaDataAction('softkey');
+		$result = $this->_start_action($write, $action, $response);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+		$this->assertTrue(is_array($result->getJSON()));
+	}
+
+    /**
+     * @\\test
+     */
+    public function can_get_SCCPShowGlobals_Skipped()
+    {
+        $write = array(implode("\r\n", array(
+            'action: SCCPShowGlobals',
+            'actionid: 1432.123',
+            ''
+        )));
+        $response = array(
+            'Response: Success',
+            'Message: SCCPShowGlobals',
+            'ConfigFile: sccp.conf',
+            ''
+        );
+        $action = new \PAMI\Message\Action\SCCPShowGlobalsAction();
+        $result = $this->_start_action($write, $action, $response);
+        $this->assertTrue($result instanceof \PAMI\Message\Response\SCCPShowGlobalsResponse);
+        $this->assertTrue($result->isSuccess());
+        $this->assertEquals($result->getConfigFile(), 'sccp.conf'); 
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPShowGlobals()
+    {
+        $responseValues = array(
+        	'SCCPShowGlobals' => array(
+				'ConfigFile' => 'sccp.conf',
+				'PlatformByteOrder' => 'LITTLE ENDIAN',
+				'ServerName' => 'moviebox',
+				'BindAddress' => '[::]:2000',
+				'ExternIP' => 'Not Set -> Using Incoming IP-addres.',
+				'Localnet' => 'permit:127.0.0.0/255.0.0.0,permit:10.0.0.0/255.0.0.0,permit:172.0.0.0/255.224.0.0,permit:192.168.0.0/255.255.0.0,',
+				'DenyPermit' => 'deny:0.0.0.0/0.0.0.0,permit:10.15.15.0/255.255.255.0,permit:127.0.0.0/255.255.255.0,',
+				'DirectRTP' => 'off',
+				'Nat' => 'Auto',
+				'Keepalive' => '60',
+				'Debug' => '(1153) none,core,channel,feature',
+				'DateFormat' => 'M/D/YA',
+				'FirstDigitTimeout' => '10',
+				'DigitTimeout' => '4',
+				'DigitTimeoutChar' => '#',
+				'SCCPTosSignaling' => '104',
+				'SCCPCosSignaling' => '4',
+				'AUDIOTosRtp' => '184',
+				'AUDIOCosRtp' => '6',
+				'VIDEOTosVrtp' => '136',
+				'VIDEOCosVrtp' => '5',
+				'Context' => 'sccp (exists)',
+				'Language' => 'en',
+				'Accountcode' => 'skinny',
+				'Musicclass' => 'default',
+				'AMAFlags' => '3 (DOCUMENTATION)',
+				'Callgroup' => '1,2',
+				'Pickupgroup' => '1,3',
+				'PickupModeAnswer' => 'on',
+				'CodecsPreference' => '(g722/64k (6), g722/56k (7), g722/48k (8))',
+				'CFWDALL' => 'on',
+				'CFWDBUSY' => 'on',
+				'CFWDNOANSWER' => 'on',
+				'CallEvents' => 'on',
+				'DNDFeatureEnabled' => 'on',
+				'Park' => 'off',
+				'PrivateSoftkey' => 'on',
+				'EchoCancel' => 'on',
+				'SilenceSuppression' => 'off',
+				'EarlyRTP' => 'Ringout',
+				'AutoAnswerRingtime' => '1',
+				'AutoAnswerTone' => '0',
+				'RemoteHangupTone' => '50',
+				'TransferTone' => '0',
+				'TransferOnHangup' => 'on',
+				'CallwaitingTone' => '45',
+				'CallwaitingInterval' => '5',
+				'RegistrationContext' => 'sccpregistration',
+				'JitterbufferEnabled' => 'on',
+				'JitterbufferForced' => 'off',
+				'JitterbufferMaxSize' => '200',
+				'JitterbufferResync' => '1000',
+				'JitterbufferImpl' => 'fixed',
+				'JitterbufferLog' => 'off',
+				'TokenFallBack' => '/usr/local/asterisk-11-branch/etc/asterisk/tokenack.sh',
+				'TokenBackoffTime' => '0',
+				'HotlineEnabled' => 'on',
+				'HotlineContext' => 'default',
+				'HotlineExten' => '500',
+				'ThreadpoolSize' => '0/2',
+			),
+        );
+        $responseTranslatedValues = array(
+        	'SCCPShowGlobals' => array(
+				'Keepalive' => 60,
+				'FirstDigitTimeout' => 10,
+				'DigitTimeout' => 4,
+				'SCCPTosSignaling' => 104,
+				'SCCPCosSignaling' => 4,
+				'AUDIOTosRtp' => 184,
+				'AUDIOCosRtp' => 6,
+				'VIDEOTosVrtp' => 136,
+				'VIDEOCosVrtp' => 5,
+				'Callgroup' => array(1,2),
+				'Pickupgroup' => array(1,3),
+				'PickupModeAnswer' => true,
+				'CodecsPreference' => array(array('name'=>'g722/64k','value'=>6), array('name'=>'g722/56k', 'value'=>7), array('name'=>'g722/48k', 'value'=>8)),
+				'CFWDALL' => true,
+				'CFWDBUSY' => true,
+				'CFWDNOANSWER' => true,
+				'CallEvents' => true,
+				'DNDFeatureEnabled' => true,
+				'Park' => false,
+				'PrivateSoftkey' => true,
+				'EchoCancel' => true,
+				'SilenceSuppression' => false,
+				'AutoAnswerRingtime' => 1,
+				'AutoAnswerTone' => 0,
+				'RemoteHangupTone' => 50,
+				'TransferTone' => 0,
+				'TransferOnHangup' => true,
+				'CallwaitingTone' => 45,
+				'CallwaitingInterval' => 5,
+				'JitterbufferEnabled' => true,
+				'JitterbufferForced' => false,
+				'JitterbufferMaxSize' => 200,
+				'JitterbufferResync' => 1000,
+				'JitterbufferLog' => false,
+				'TokenBackoffTime' => 0,
+				'HotlineEnabled' => true,
+			),
+        );
+        $responseGetters = array(
+        );
+        foreach (array_keys($responseValues) as $responseName) {
+            $result = $this->_testActionResponse($responseName, $responseGetters, $responseValues[$responseName], $responseTranslatedValues);
+        }
+        $this->assertTrue($result instanceof \PAMI\Message\Response\SCCPShowGlobalsResponse);
+        $this->assertTrue($result->isSuccess());
+        $this->assertFalse($result->hasTable());
+    }
+
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowDevices()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowDevices',
+			'actionid: 1432.123',
+			''
+		)));
+        $response = array(implode("\r\n",  array(
+			'Response: Success',
+			'ActionID: 1432.123',
+			'EventList: start',
+			'Message: SCCPShowDevices list will follow',
+			'',
+			'Event: TableStart',
+			'TableName: Devices',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPDeviceEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Device',
+			'ActionID: 1432.123',
+			'Descr: Phone Féour',
+			'Address: [::ffff:10.11.11.111]:51887',
+			'Mac: SEP001122334455',
+			'RegState: OK',
+			'Token: No Token',
+			'RegTime: Tue Apr  7 21:17:28 2015',
+			'Act: No',
+			'Lines: 2',
+			'Nat: (Auto)Off',
+			'',
+			'Event: SCCPDeviceEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Device',
+			'ActionID: 1432.123',
+			'Descr: Diederik de Groot',
+			'Address: [::ffff:10.11.11.112]:50718',
+			'Mac: SEP0024C4446974',
+			'RegState: OK',
+			'Token: No Token',
+			'RegTime: Tue Apr  7 21:17:28 2015',
+			'Act: No',
+			'Lines: 2',
+			'Nat: (Auto)Off',
+			'',
+			'Event: TableEnd',
+			'TableName: Devices',
+			'TableEntries: 2',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPShowDevicesComplete',
+			'EventList: Complete',
+			'ListItems: 15',
+			'ListTableItems: 1',
+			'ActionID: 1432.123',
+            '',
+        )));
+		$action = new \PAMI\Message\Action\SCCPShowDevicesAction();
+		$result = $this->_start_action($write, $action, $response);
+
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($result->hasTable());
+        $this->assertTrue(is_array($result->getTableNames()));
+        $this->assertTrue(is_array($result->getTable('Devices')));
+        #$this->setExpectedException('PAMIException');
+        #$this->assertFalse(is_array($result->getTable('NotATable')));
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_get_SCCPShowDevices_NonexistentTable()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowDevices',
+			'actionid: 1432.123',
+			''
+		)));
+        $response = array(implode("\r\n",  array(
+			'Response: Success',
+			'ActionID: 1432.123',
+			'EventList: start',
+			'Message: SCCPShowDevices list will follow',
+			'',
+			'Event: TableStart',
+			'TableName: Devices',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPDeviceEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Device',
+			'ActionID: 1432.123',
+			'Descr: Phone Féour',
+			'Address: [::ffff:10.11.11.111]:51887',
+			'Mac: SEP001122334455',
+			'RegState: OK',
+			'Token: No Token',
+			'RegTime: Tue Apr  7 21:17:28 2015',
+			'Act: No',
+			'Lines: 2',
+			'Nat: (Auto)Off',
+			'',
+			'Event: SCCPDeviceEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Device',
+			'ActionID: 1432.123',
+			'Descr: Diederik de Groot',
+			'Address: [::ffff:10.11.11.112]:50718',
+			'Mac: SEP0024C4446974',
+			'RegState: OK',
+			'Token: No Token',
+			'RegTime: Tue Apr  7 21:17:28 2015',
+			'Act: No',
+			'Lines: 2',
+			'Nat: (Auto)Off',
+			'',
+			'Event: TableEnd',
+			'TableName: Devices',
+			'TableEntries: 2',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPShowDevicesComplete',
+			'EventList: Complete',
+			'ListItems: 15',
+			'ListTableItems: 1',
+			'ActionID: 1432.123',
+            '',
+        )));
+		$action = new \PAMI\Message\Action\SCCPShowDevicesAction();
+		$result = $this->_start_action($write, $action, $response);
+
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPGenericResponse);
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($result->hasTable());
+        $this->assertTrue(is_array($result->getTable('NotATable')));		/* Table does not exist */
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowDevice()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowDevice',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowDeviceAction('SEP001122334455');
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowDevice_Additional()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowDevice',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			''
+		)));
+		$response = array(
+			'Response: Success',
+			'EventList: start',
+			'ActionID: 1432.123',
+			'Message: SCCPShowDevice list will follow',
+			'',
+			'Event: SCCPShowDevice',
+			'ActionID: 1432.123',
+			'MACAddress: SEP0023043403F9',
+			'',
+			'Event: SCCPShowDeviceComplete',
+			'ActionID: 1432.123',
+			'EventList: Complete',
+			'ListItems: 304',
+			'',
+		);
+		$action = new \PAMI\Message\Action\SCCPShowDeviceAction('SEP001122334455');
+		$result = $this->_start_action($write, $action, $response);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowLines()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowLines',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowLinesAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowLine()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowLine',
+			'actionid: 1432.123',
+			'linename: MyLine',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowLineAction('MyLine');
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowChannels()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowChannels',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowChannelsAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @//test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_get_SCCPShowChannels()
+	{
+		$write = array(implode("\r\n", array(
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowChannelsAction('xxx');
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowSessions()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowSessions',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowSessionsAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * Test SCCPShowMWISubscriptions  action message.
+	 * @test
+	 */
+	public function can_get_SCCPShowMWISubscriptions()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowMWISubscriptions',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowMWISubscriptionsAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * Test SCCPShowSoftkeySets  action message.
+	 * @test
+	 */
+	public function can_get_SCCPShowSoftkeySets()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowSoftkeySets',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowSoftkeySetsAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * Test SCCPShowConferences  action message.
+	 * @test
+	 */
+	public function can_get_SCCPShowConferences()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowConferences',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowConferencesAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * Test SCCPShowHintLineStates  action message.
+	 * @test
+	 */
+	public function can_get_SCCPShowHintLineStates()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowHintLineStates',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowHintLineStatesAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * Test SCCPShowHintSubscriptions  action message.
+	 * @test
+	 */
+	public function can_get_SCCPShowHintSubscriptions()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowHintSubscriptions',
+			'actionid: 1432.123',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowHintSubscriptionsAction();
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPAnswerCall()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPAnswerCall1',
+			'actionid: 1432.123',
+			'channelid: 98011',
+			'deviceid: SEP001122334455',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPAnswerCallAction('98011', 'SEP001122334455');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPConference_Endconf()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: endconf',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'endconf');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPConference_Kick()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: kick',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'Kick');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPConference_Mute()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: mute',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'Mute');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPConference_Invite()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: invite',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'Invite');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_SCCPConference_Moderate()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: moderate',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'moderate');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPConference_with_wrong_comand()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: hangup',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'hangup');
+		$result = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function cannot_SCCPConference_with_wrong_conferenceid_handle_error_returned()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			'participantid: 1',
+			'command: kick',
+			''
+		)));
+		$response = array(
+			'Response: Error',
+			'ActionID: 1432.123',
+			'Message: Conference 100 not found',
+			'',
+		);
+		$action = new \PAMI\Message\Action\SCCPConferenceAction('100', '1', 'kick');
+		$result = $this->_start_action($write, $action, $response);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceAddLine()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceAddLine',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceAddLineAction('SEP001122334455', '12345');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceRestart_restart()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceRestart',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'type: restart',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceRestartAction('SEP001122334455','restart');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceRestart_full()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceRestart',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'type: full',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceRestartAction('SEP001122334455','full');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceRestart_reset()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceRestart',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'type: reset',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceRestartAction('SEP001122334455','reset');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPDeviceRestart_with_wrong_Type()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceRestart',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'type: boo',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceRestartAction('SEP001122334455','boo');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceSetDND_on()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceSetDND',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'dndstate: on',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceSetDNDAction('SEP001122334455', 'on');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceSetDND_reject()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceSetDND',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'dndstate: reject',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceSetDNDAction('SEP001122334455', 'reject');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceSetDND_silent()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceSetDND',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'dndstate: silent',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceSetDNDAction('SEP001122334455', 'silent');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceSetDND_off()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceSetDND',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'dndstate: off',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceSetDNDAction('SEP001122334455', 'off');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPDeviceSetDND_with_wrong_dndstate()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceSetDND',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'dndstate: boo',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceSetDNDAction('SEP001122334455', 'boo');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDeviceUpdate()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDeviceUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDeviceUpdateAction('SEP001122334455');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDndDevice_off()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDndDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'state: off',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDndDeviceAction('SEP001122334455', 'off');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDndDevice_reject()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDndDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'state: reject',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDndDeviceAction('SEP001122334455', 'reject');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPDndDevice_silent()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDndDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'state: silent',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDndDeviceAction('SEP001122334455', 'silent');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPDndDevice_with_wrong_state()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPDndDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'state: boo',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPDndDeviceAction('SEP001122334455', 'boo');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPHangupCall()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPHangupCall',
+			'actionid: 1432.123',
+			'channelid: SCCP/003423-432',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPHangupCallAction('SCCP/003423-432');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPHoldCall_hold()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPHoldCall',
+			'actionid: 1432.123',
+			'channelid: SCCP/003423-432',
+			'devicename: SEP001122334455',
+			'hold: on',
+			'swapchannels: off',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPHoldCallAction('SCCP/003423-432', 'SEP001122334455', true);
+		$client = $this->_start($write, $action);
+	}
+
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPHoldCall_resume()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPHoldCall',
+			'actionid: 1432.123',
+			'channelid: SCCP/003423-432',
+			'devicename: SEP001122334455',
+			'hold: off',
+			'swapchannels: on',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPHoldCallAction('SCCP/003423-432', 'SEP001122334455', false, true);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPHoldCall_hold_and_swapchannels()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPHoldCall',
+			'actionid: 1432.123',
+			'channelid: SCCP/003423-432',
+			'devicename: SEP001122334455',
+			'hold: on',
+			'swapchannels: on',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPHoldCallAction('SCCP/003423-432', 'SEP001122334455', true, true);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPLineForwardUpdate_ForwardAll()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPLineForwardUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			'forwardtype: all',
+			'number: 666',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPLineForwardUpdateAction('SEP001122334455','12345','all',false, '666');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPLineForwardUpdate_ForwardBusy()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPLineForwardUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			'forwardtype: busy',
+			'number: 666',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPLineForwardUpdateAction('SEP001122334455','12345','busy',false,'666');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPLineForwardUpdate_forward_with_wrong_type()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPLineForwardUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			'forwardtype: boo',
+			'number: 666',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPLineForwardUpdateAction('SEP001122334455','12345','boo',false,'666');
+		$client = $this->_start($write, $action);
+	}
+
+
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPLineForwardUpdate_Disable()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPLineForwardUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			'forwardtype: all',
+			'disable: on',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPLineForwardUpdateAction('SEP001122334455','12345','all',true);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 * @expectedException \PAMI\Exception\PAMIException
+	 */
+	public function cannot_SCCPLineForwardUpdate_FailOnNumber()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPLineForwardUpdate',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 12345',
+			'forwardtype: all',
+			'disable: on',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPLineForwardUpdateAction('SEP001122334455','12345','all',true,'666');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevices()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevices',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDevicesAction('Text to send to all devices', false, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevices_beep()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevices',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDevicesAction('Text to send to all devices', true, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevices_beep_timeout()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevices',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			'timeout: 10',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDevicesAction('Text to send to all devices', true, 10);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevice()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'messagetext: Text to send to all devices',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDeviceAction('SEP001122334455', 'Text to send to all devices', false, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevice_beep()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDeviceAction('SEP001122334455', 'Text to send to all devices', true, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPMessageDevice_beep_timeout()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPMessageDevice',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			'timeout: 10',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPMessageDeviceAction('SEP001122334455', 'Text to send to all devices', true, 10);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPSystemMessage()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPSystemMessage',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPSystemMessageAction('Text to send to all devices', false, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPSystemMessage_beep()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPSystemMessage',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPSystemMessageAction('Text to send to all devices', true, false);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPSystemMessage_timeout()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPSystemMessage',
+			'actionid: 1432.123',
+			'messagetext: Text to send to all devices',
+			'beep: beep',
+			'timeout: 10',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPSystemMessageAction('Text to send to all devices', true, 10);
+		$client = $this->_start($write, $action);
+	}
+
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowConference()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowConference',
+			'actionid: 1432.123',
+			'conferenceid: 100',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPShowConferenceAction(100);
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPStartCall()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPStartCall',
+			'actionid: 1432.123',
+			'devicename: SEP001122334455',
+			'linename: 98011',
+			'number: 666',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPStartCallAction('SEP001122334455','98011','666');
+		$client = $this->_start($write, $action);
+	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPTokenAck()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPTokenAck',
+			'actionid: 1432.123',
+			'deviceid: SEP001122334455',
+			''
+		)));
+		$action = new \PAMI\Message\Action\SCCPTokenAckAction('SEP001122334455');
+		$client = $this->_start($write, $action);
+	}
+
+    private function _testActionResponse($actionName, array $getters, array $values, array $translatedValues)
+    {
+        $actionClass = "\\PAMI\\Message\\Action\\" . $actionName . 'Action';
+        $resultClass = "\\PAMI\\Message\\Response\\" . $actionName . 'Response';
+
+        $write = array(implode("\r\n", array(
+            'action: ' . $actionName,
+            'actionid: 1432.123',
+            ''
+        )));
+
+	    $response = array();
+	    $response[] = 'Response: ' . $actionName;
+	    foreach ($values as $key => $value) {
+	        $response[] = $key . ': ' . $value;
+	    }
+	    $response[] = '';
+
+		$action = new $actionClass;
+		$result = $this->_start_action($write, $action, $response, true);
+
+		// cheating on timeout ?...
+	    /*
+	    for($i = 0; $i < count($response); $i++) {
+	        $result->process();
+	    }
+	    */
+		$this->assertTrue($result instanceof $resultClass, "Class '" . get_class($result) . "' is not an instance of '$resultClass'");
+		$this->assertTrue($result->isSuccess());
+
+        foreach ($values as $key => $value) {
+            if (isset($getters[$actionName][$key])) {
+                $methodName = 'get' . $getters[$actionName][$key];
+            } else {
+                $methodName = 'get' . $key;
+            }
+            if (isset($translatedValues[$actionName][$key])) {
+                $value = $translatedValues[$actionName][$key];
+            }
+            $this->assertEquals($result->$methodName(), $value, "Action: '$actionName'->'$methodName' to retrieve Key: '$key', returned Value: '". var_dump($result->$methodName()) ."' instead of expected: '" . var_dump($value) . "'");
+		}
+		return $result;
+    }
+
+}
+}

--- a/test/sccp_actions/SCCP_Test_Actions.php
+++ b/test/sccp_actions/SCCP_Test_Actions.php
@@ -248,11 +248,6 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
      */
     public function can_get_SCCPShowGlobals_Skipped()
     {
-        $write = array(implode("\r\n", array(
-            'action: SCCPShowGlobals',
-            'actionid: 1432.123',
-            ''
-        )));
         $response = array(
             'Response: Success',
             'Message: SCCPShowGlobals',
@@ -271,6 +266,11 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
      */
     public function can_get_SCCPShowGlobals()
     {
+        $write = array(implode("\r\n", array(
+            'action: SCCPShowGlobals',
+            'actionid: 1432.123',
+            ''
+        )));
         $responseValues = array(
         	'SCCPShowGlobals' => array(
 				'ConfigFile' => 'sccp.conf',
@@ -539,40 +539,363 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
 			'devicename: SEP001122334455',
 			''
 		)));
-		$action = new \PAMI\Message\Action\SCCPShowDeviceAction('SEP001122334455');
-		$result = $this->_start($write, $action);
-	}
-
-	/**
-	 * @test
-	 */
-	public function can_get_SCCPShowDevice_Additional()
-	{
-		$write = array(implode("\r\n", array(
-			'action: SCCPShowDevice',
-			'actionid: 1432.123',
-			'devicename: SEP001122334455',
-			''
-		)));
 		$response = array(
 			'Response: Success',
 			'EventList: start',
-			'ActionID: 1432.123',
+			'ActionId: 1432.123',
 			'Message: SCCPShowDevice list will follow',
 			'',
 			'Event: SCCPShowDevice',
-			'ActionID: 1432.123',
+			'ActionId: 1432.123',
 			'MACAddress: SEP0023043403F9',
+			'ProtocolVersion: Supported \'22\', In Use \'22\'',
+			'ProtocolInUse: SCCP Version 22',
+			'DeviceFeatures: 0x85720016,10000101011100100000000000010110',
+			'Tokenstate: No Token',
+			'Keepalive: 60',
+			'RegistrationState: OK(5)',
+			'State: On Hook(0)',
+			'MWILight: On(2)',
+			'MWIHandsetLight: off',
+			'Description: Phone Féour',
+			'ConfigPhoneType: bl7970',
+			'SkinnyPhoneType: Cisco 7970(30006)',
+			'SoftkeySupport: yes',
+			'Softkeyset: my_softkeyset (0x7f2f08020af0)',
+			'BTemplateSupport: yes',
+			'linesRegistered: yes',
+			'ImageVersion: term70.default',
+			'TimezoneOffset: 0',
+			'Capabilities: (slin16 (25), g722/64k (6), ulaw/64k (4), alaw/64k (2), g722/56k (7), g722/48k (8), g729b (15), g729ab (16), g729 (11), g729a (12), rfc2833 (257))',
+			'CodecsPreference: (g722/64k (6), g722/56k (7), g722/48k (8), alaw/64k (2), alaw/56k (3), ulaw/64k (4), ulaw/56k (5), g729 (11), g729a (12), g729b (15), g729ab (16), g729/annex/b (85))',
+			'AudioTOS: 184',
+			'AudioCOS: 6',
+			'VideoTOS: 136',
+			'VideoCOS: 5',
+			'DNDFeatureEnabled: yes',
+			'DNDStatus: Disabled',
+			'DNDAction: Reject',
+			'CanTransfer: on',
+			'CanPark: on',
+			'CanCFWDALL: on',
+			'CanCFWBUSY: off',
+			'CanCFWNOANSWER: off',
+			'AllowRinginNotification: no',
+			'PrivateSoftkey: on',
+			'DtmfMode: RFC2833',
+			'Nat: (Auto)Off',
+			'Videosupport: no',
+			'DirectRTP: off',
+			'TrustPhoneIpDeprecated: off',
+			'BindAddress: [::ffff:10.15.15.205]:52899',
+			'ServerAddress: [::ffff:10.15.15.195]:52781',
+			'DenyPermit: deny:0.0.0.0/0.0.0.0,permit:10.15.15.0/255.255.255.0,permit:127.0.0.0/255.255.255.0,',
+			'PermitHosts: ',
+			'EarlyRTP: Ringout',
+			'DeviceStateAcc: Off Hook',
+			'LastUsedAccessory: Handset',
+			'LastDialedNumber: ',
+			'DefaultLineInstance: 1',
+			'CustomBackgroundImage: http://10.15.15.195:8088/static/strand.png',
+			'CustomRingTone: ---',
+			'UsePlacedCalls: on',
+			'PendingUpdate: off',
+			'PendingDelete: off',
+			'DirectedPickup: on',
+			'PickupContext: sccp (exists)',
+			'PickupModeAnswer: on',
+			'allowConference: on',
+			'confPlayGeneralAnnounce: on',
+			'confPlayPartAnnounce: on',
+			'confMuteOnEntry: on',
+			'confMusicOnHoldClass: default',
+			'confShowConflist: on',
+			'conflistActive: off',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: Buttons',
+			'',
+			'Event: SCCPDeviceButtonEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceButton',
+			'Id: 1',
+			'Inst: 1',
+			'TypeStr: Line',
+			'Type: 0',
+			'pendUpdt: No',
+			'pendDel: No',
+			'Default: Yes',
+			'',
+			'Event: SCCPDeviceButtonEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceButton',
+			'Id: 2',
+			'Inst: 2',
+			'TypeStr: Line',
+			'Type: 0',
+			'pendUpdt: No',
+			'pendDel: No',
+			'Default: No',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: Buttons',
+			'TableEntries: 2',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: LineButtons',
+			'',
+			'Event: SCCPDeviceLineEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceLine',
+			'Id: 1',
+			'Name: 98041',
+			'Suffix: ',
+			'Label: Phone 4 Line 1',
+			'CfwdType: None',
+			'CfwdNumber: ',
+			'',
+			'Event: SCCPDeviceLineEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceLine',
+			'Id: 2',
+			'Name: 98099',
+			'Suffix: 4',
+			'Label: Shared',
+			'CfwdType: None',
+			'CfwdNumber: ',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: LineButtons',
+			'TableEntries: 2',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: SpeeddialButtons',
+			'',
+			'Event: SCCPDeviceSpeeddialEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceSpeeddial',
+			'Id: 3',
+			'Name: 98011',
+			'Number: 98011',
+			'Hint: 98011@hints',
+			'',
+			'Event: SCCPDeviceSpeeddialEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceSpeeddial',
+			'Id: 4',
+			'Name: 98031',
+			'Number: 98031',
+			'Hint: 98031@hints',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: SpeeddialButtons',
+			'TableEntries: 2',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: FeatureButtons',
+			'',
+			'Event: SCCPDeviceFeatureEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceFeature',
+			'Id: 8',
+			'Name: call forwared',
+			'Options: 500',
+			'Status: 0',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: FeatureButtons',
+			'TableEntries: 1',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: ServiceURLButtons',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: ServiceURLButtons',
+			'TableEntries: 0',
+			'',
+			'Event: TableStart',
+			'TableName: Variables',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPVariableEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Variable',
+			'ActionID: 1432.123',
+			'Name: testvariable1',
+			'Value: myval1',
+			'',
+			'Event: SCCPVariableEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Variable',
+			'ActionID: 1432.123',
+			'Name: testvariable2',
+			'Value: myval2',
+			'',
+			'Event: TableEnd',
+			'TableName: Variables',
+			'TableEntries: 2',
+			'ActionID: 1432.123',
+			'',
+			'Event: TableStart',
+			'ActionId: 1432.123',
+			'TableName: CallStatistics',
+			'',
+			'Event: SCCPDeviceStatisticsEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceStatistics',
+			'Type: LAST',
+			'Calls: 0',
+			'PcktSnt: 0',
+			'PcktRcvd: 0',
+			'Lost: 0',
+			'Jitter: 0',
+			'Latency: 0',
+			'Quality: 0.000000',
+			'avgQual: 0.000000',
+			'meanQual: 0.000000',
+			'maxQual: 0.000000',
+			'rConceal: 0.000000',
+			'sConceal: 0',
+			'',
+			'Event: SCCPDeviceStatisticsEntry',
+			'ActionId: 1432.123',
+			'ChannelType: SCCP',
+			'ChannelObjectType: DeviceStatistics',
+			'Type: AVG',
+			'Calls: 0',
+			'PcktSnt: 0',
+			'PcktRcvd: 0',
+			'Lost: 0',
+			'Jitter: 0',
+			'Latency: 0',
+			'Quality: 0.000000',
+			'avgQual: 0.000000',
+			'meanQual: 0.000000',
+			'maxQual: 0.000000',
+			'rConceal: 0.000000',
+			'sConceal: 0',
+			'',
+			'Event: TableEnd',
+			'ActionId: 1432.123',
+			'TableName: CallStatistics',
+			'TableEntries: 2',
 			'',
 			'Event: SCCPShowDeviceComplete',
-			'ActionID: 1432.123',
+			'ActionId: 1432.123',
 			'EventList: Complete',
-			'ListItems: 304',
-			'',
+			'ListItems: 291',
+			'ListTableItems: 6',
+			''
 		);
 		$action = new \PAMI\Message\Action\SCCPShowDeviceAction('SEP001122334455');
 		$result = $this->_start_action($write, $action, $response);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPShowDeviceResponse);
+        $this->assertTrue($result->isSuccess());
+        $this->assertTrue($result->isList());
+		$events = $result->getEvents(); 
+		$keyvalues = array(
+			'MACAddress' => 'SEP0023043403F9',
+			'ProtocolVersion' => 'Supported \'22\', In Use \'22\'',
+			'ProtocolInUse' => 'SCCP Version 22',
+			'DeviceFeatures' => '0x85720016,10000101011100100000000000010110',
+			'Tokenstate' => 'No Token',
+			'Keepalive' => 60,
+			'RegistrationState' => 'OK(5)',
+			'State' => 'On Hook(0)',
+			'MWILight' => 'On(2)',
+			'MWIHandsetLight' => false,
+			'Description' => 'Phone Féour',
+			'ConfigPhoneType' => 'bl7970',
+			'SkinnyPhoneType' => 'Cisco 7970(30006)',
+			'SoftkeySupport' => true,
+			'Softkeyset' => 'my_softkeyset (0x7f2f08020af0)',
+			'BTemplateSupport' => true,
+			'linesRegistered' => true,
+			'ImageVersion' => 'term70.default',
+			'TimezoneOffset' => 0,
+			//				'Capabilities' => '(slin16 (25), g722/64k (6), ulaw/64k (4), alaw/64k (2), g722/56k (7), g722/48k (8), g729b (15), g729ab (16), g729 (11), g729a (12), rfc2833 (257))',
+			//				'CodecsPreference' => '(g722/64k (6), g722/56k (7), g722/48k (8), alaw/64k (2), alaw/56k (3), ulaw/64k (4), ulaw/56k (5), g729 (11), g729a (12), g729b (15), g729ab (16), g729/annex/b (85))',
+			'AudioTOS' => 184,
+			'AudioCOS' => 6,
+			'VideoTOS' => 136,
+			'VideoCOS' => 5,
+			'DNDFeatureEnabled' => true,
+			'DNDStatus' => 'Disabled',
+			'DNDAction' => 'Reject',
+			'CanTransfer' => true,
+			'CanPark' => true,
+			'CanCFWDALL' => true,
+			'CanCFWBUSY' => false,
+			'CanCFWNOANSWER' => false,
+			'AllowRinginNotification' => false,
+			'PrivateSoftkey' => true,
+			'DtmfMode' => 'RFC2833',
+			'Nat' => '(Auto)Off',
+			'Videosupport' => false,
+			'DirectRTP' => false,
+			'BindAddress' => '[::ffff:10.15.15.205]:52899',
+			'ServerAddress' => '[::ffff:10.15.15.195]:52781',
+			//				'DenyPermit' => 'deny:0.0.0.0/0.0.0.0,permit:10.15.15.0/255.255.255.0,permit:127.0.0.0/255.255.255.0,',
+			'PermitHosts' => '',
+			'EarlyRTP' => 'Ringout',
+			'DeviceStateAcc' => 'Off Hook',
+			'LastUsedAccessory' => 'Handset',
+			'LastDialedNumber' => '',
+			'DefaultLineInstance' => 1,
+			'CustomBackgroundImage' => 'http://10.15.15.195:8088/static/strand.png',
+			'CustomRingTone' => '---',
+			'UsePlacedCalls' => true,
+			'PendingUpdate' => false,
+			'PendingDelete' => false,
+			'DirectedPickup' => true,
+			'PickupContext' => 'sccp (exists)',
+			'PickupModeAnswer' => true,
+			'allowConference' => true,
+			'confPlayGeneralAnnounce' => true,
+			'confPlayPartAnnounce' => true,
+			'confMuteOnEntry' => true,
+			'confMusicOnHoldClass' => 'default',
+			'confShowConflist' => true,
+			'conflistActive' => false
+		);
+		$this->assertEquals($result->getDeviceName(), "SEP0023043403F9"); 
+		foreach ($keyvalues as $key => $value) {
+			$method='get' . $key;
+			$this->assertEquals($result->$method(), $value, 'value[' . $result->$method() . '] of key: "' . $key . '" does not match expected ['. $value . "]\n");
+		} 
+		$this->assertTrue(is_array($result->getDenyPermit()));
+		$this->assertTrue(is_array($result->getCapabilities()));
+		$this->assertTrue(is_array($result->getCodecsPreference()));
+
+		$this->assertTrue($result->hasTable());
+		$this->assertEquals(array('Buttons','LineButtons','SpeeddialButtons','FeatureButtons','ServiceURLButtons','Variables','CallStatistics'), $result->getTableNames());
+		$this->assertTrue(is_array($result->getTableNames()));
+		$subtablenamess=array('Buttons','LineButtons','SpeeddialButtons','FeatureButtons','ServiceURLButtons','Variables','CallStatistics'); 
+		foreach ($subtablenamess as $subtablename) {
+			$getmethod = 'get' . $subtablename;
+			$this->assertTrue(is_array($result->$getmethod()));
+		}
+		$this->assertEquals('Buttons', $result->getButtons()['Name']);
 	}
+
 
 	/**
 	 * @test
@@ -589,9 +912,9 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @test
+	 * @\\test
 	 */
-	public function can_get_SCCPShowLine()
+	public function can_get_SCCPShowLine_bak()
 	{
 		$write = array(implode("\r\n", array(
 			'action: SCCPShowLine',
@@ -602,6 +925,192 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
 		$action = new \PAMI\Message\Action\SCCPShowLineAction('MyLine');
 		$result = $this->_start($write, $action);
 	}
+
+	/**
+	 * @test
+	 */
+	public function can_get_SCCPShowLine()
+	{
+		$write = array(implode("\r\n", array(
+			'action: SCCPShowLine',
+			'actionid: 1432.123',
+			'linename: 98011',
+			''
+		)));
+		$response = array(
+			'Response: Success',
+			'ActionID: 1432.123',
+			'EventList: start',
+			'Message: SCCPShowLine list will follow',
+			'',
+			'Event: SCCPShowLine',
+			'ActionID: 1432.123',
+			'Name: 98011',
+			'Description: chan-sccp.net',
+			'Label: Diederik de Groot (98011)',
+			'ID: 0005',
+			'Pin: 9944',
+			'VoiceMailNumber: *998011',
+			'TransferToVoicemail: 699',
+			'MeetMeEnabled: on',
+			'MeetMeNumber: ',
+			'MeetMeOptions: qxd',
+			'Context: sccp (exists)',
+			'Language: nl',
+			'AccountCode: 98011',
+			'Musicclass: default',
+			'AmaFlags: 0',
+			'CallGroup: 1',
+			'PickupGroup: 1',
+			'NamedCallGroup: engineering,sales,netgroup,protgroup',
+			'NamedPickupGroup: sales',
+			'ParkingLot: default',
+			'CallerIDName: Diederik de Groot (98011)',
+			'CallerIDNumber: 98011',
+			'IncomingCallsLimit: 3',
+			'ActiveChannelCount: 0',
+			'SecDialtoneDigits: 9',
+			'SecDialtone: 0x22',
+			'EchoCancellation: on',
+			'SilenceSuppression: off',
+			'CanTransfer: on',
+			'DNDAction: Reject',
+			'IsRealtimeLine: on',
+			'PendingDelete: off',
+			'PendingUpdate: off',
+			'RegistrationExtension: ',
+			'RegistrationContext: ',
+			'AdhocNumberAssigned: on',
+			'MessageWaitingNew: 0',
+			'MessageWaitingOld: 0',
+			'',
+			'Event: TableStart',
+			'TableName: AttachedDevices',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPAttachedDeviceEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: AttachedDevice',
+			'ActionID: 1432.123',
+			'DeviceName: SEP001B54CA499B',
+			'CfwdType: ',
+			'CfwdNumber: ',
+			'',
+			'Event: TableEnd',
+			'TableName: AttachedDevices',
+			'TableEntries: 1',
+			'ActionID: 1432.123',
+			'',
+			'Event: TableStart',
+			'TableName: Mailboxes',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPMailboxEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Mailbox',
+			'ActionID: 1432.123',
+			'mailbox: 98011',
+			'context: default',
+			'',
+			'Event: TableEnd',
+			'TableName: Mailboxes',
+			'TableEntries: 1',
+			'ActionID: 1432.123',
+			'',
+			'Event: TableStart',
+			'TableName: Variables',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPVariableEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Variable',
+			'ActionID: 1432.123',
+			'Name: testvariable1',
+			'Value: myval1',
+			'',
+			'Event: SCCPVariableEntry',
+			'ChannelType: SCCP',
+			'ChannelObjectType: Variable',
+			'ActionID: 1432.123',
+			'Name: testvariable2',
+			'Value: myval2',
+			'',
+			'Event: TableEnd',
+			'TableName: Variables',
+			'TableEntries: 2',
+			'ActionID: 1432.123',
+			'',
+			'Event: SCCPShowLineComplete',
+			'EventList: Complete',
+			'ListItems: 68',
+			'ListTableItems: 2',
+			'ActionID: 1432.123',
+			''
+		);
+		$action = new \PAMI\Message\Action\SCCPShowLineAction('98011');
+		$result = $this->_start_action($write, $action, $response);
+		$this->assertTrue($result instanceof \PAMI\Message\Response\SCCPShowLineResponse);
+        $this->assertTrue($result->isSuccess());
+		$this->assertTrue($result->isList());
+		$events = $result->getEvents(); 
+		$keyvalues = array(
+			'Name' => '98011',
+			'Description' => 'chan-sccp.net',
+			'Label' => 'Diederik de Groot (98011)',
+			'ID' => '0005',
+			'Pin' => '9944',
+			'VoiceMailNumber' => '*998011',
+			'TransferToVoicemail' => '699',
+			'MeetMeEnabled' => true,
+			'MeetMeNumber' => '',
+			'MeetMeOptions' => 'qxd',
+			'Context' => 'sccp (exists)',
+			'Language' => 'nl',
+			'AccountCode' => '98011',
+			'Musicclass' => 'default',
+			'AmaFlags' => 0,
+			//'CallGroup' => 1,
+			//'PickupGroup' => 1,
+			//'NamedCallGroup' => 'engineering,sales,netgroup,protgroup',
+			//'NamedPickupGroup' => 'sales',
+			'ParkingLot' => 'default',
+			'CallerIDName' => 'Diederik de Groot (98011)',
+			'CallerIDNumber' => '98011',
+			'IncomingCallsLimit' => 3,
+			'ActiveChannelCount' => 0,
+			'SecDialtoneDigits' => 9,
+			'SecDialtone' => '0x22',
+			'EchoCancellation' => true,
+			'SilenceSuppression' => false,
+			'CanTransfer' => true,
+			'DNDAction' => 'Reject',
+			'IsRealtimeLine' => true,
+			'PendingDelete' => false,
+			'PendingUpdate' => false,
+			'RegistrationExtension' => '',
+			'RegistrationContext' => '',
+			'AdhocNumberAssigned' => true,
+			'MessageWaitingNew' => 0,
+			'MessageWaitingOld' => 0,
+		);
+		$this->assertEquals($result->getName(), "98011"); 
+		foreach ($keyvalues as $key => $value) {
+			$method='get' . $key;
+			$this->assertEquals($result->$method(), $value, 'value[' . $result->$method() . '] of key: "' . $key . '" does not match expected ['. $value . "]\n");
+		} 
+		$this->assertTrue(is_array($result->getCallGroup()));
+		$this->assertTrue(is_array($result->getPickupGroup()));
+		$this->assertTrue(is_array($result->getNamedCallGroup()));
+		$this->assertTrue(is_array($result->getNamedPickupGroup()));
+
+		$this->assertTrue($result->hasTable());
+		$this->assertEquals(array('AttachedDevices','Mailboxes','Variables'), $result->getTableNames());
+		$this->assertTrue(is_array($result->getTableNames()));
+		$this->assertTrue(is_array($result->getAttachedDevices()));
+		$this->assertTrue(is_array($result->getMailboxes()));
+		$this->assertTrue(is_array($result->getVariables()));
+	}
+
 
 	/**
 	 * @test
@@ -1481,7 +1990,7 @@ class SCCP_Test_Actions extends \PHPUnit_Framework_TestCase
 	    }
 	    $response[] = '';
 
-		$action = new $actionClass;
+		$action = new $actionClass();
 		$result = $this->_start_action($write, $action, $response, true);
 
 		// cheating on timeout ?...

--- a/test/sccp_events/SCCP_Test_Events.php
+++ b/test/sccp_events/SCCP_Test_Events.php
@@ -1,0 +1,1202 @@
+<?php
+/**
+ * This class will test some events.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage Event
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Client\Impl {
+/**
+ * This class will test some events.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage Event
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @link       http://marcelog.github.com/
+ */
+class SCCP_Test_Events extends \PHPUnit_Framework_TestCase
+{
+    private $_properties = array();
+
+    public function setUp()
+    {
+        $this->_properties = array(
+            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+        );
+    }
+
+	/**
+     * @test
+     */
+    public function can_get_table_events()
+    {
+        $eventValues = array(
+        	'TableStart' => array(
+        		'TableName' => 'Start'
+			),
+        	'TableEnd' => array(
+        		'TableName' => 'End'
+			),
+        );
+        $eventTranslatedValues = array(
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_showdevices_events()
+    {
+        $eventValues = array(
+        	'SCCPDeviceEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Device',
+				'Descr' => 'Phone Féour',
+				'Address' => '[::ffff:10.15.15.205]:53108',
+				'Mac' => 'SEP0023043403F9',
+				'RegState' => 'OK',
+				'Token' => 'No Token',
+				'RegTime' => 'Sat Apr  4 23:36:53 2015',
+				'Act' => 'No',
+				'Lines' => '2',
+				'Nat' => '(Auto)Off'
+        	),
+            'SCCPShowDevicesComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+        	'SCCPDeviceEntry' => array(
+        		'Act' => false,
+				'Lines' => 2,
+        	),
+            'SCCPShowDevicesComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        	'SCCPDeviceEntry' => array(
+        		'Act' => 'Active',
+        		'Descr' => 'Description',
+			),
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_showdevice_events()
+    {
+        $eventValues = array(
+            'SCCPShowDevice' => array(
+				'MACAddress' => 'SEP0023043403F9',
+				'ProtocolVersion' => 'Supported \'22\', In Use \'22\'',
+				'ProtocolInUse' => 'SCCP Version 22',
+				'DeviceFeatures' => '0x85720016,10000101011100100000000000010110',
+				'Tokenstate' => 'No Token',
+				'Keepalive' => '60',
+				'RegistrationState' => 'OK(5)',
+				'State' => 'On Hook(0)',
+				'MWILight' => 'On(2)',
+				'MWIHandsetLight' => 'off',
+				'Description' => 'Phone Féour',
+				'ConfigPhoneType' => 'bl7970',
+				'SkinnyPhoneType' => 'Cisco 7970(30006)',
+				'SoftkeySupport' => 'yes',
+				'Softkeyset' => 'my_softkeyset (0x7fa9d40f1ba0)',
+				'BTemplateSupport' => 'yes',
+				'LinesRegistered' => 'yes',
+				'ImageVersion' => 'term70.default',
+				'TimezoneOffset' => '0',
+				'Capabilities' => '(slin16 (25), g722/64k (6), ulaw/64k (4))',
+				'CodecsPreference' => '(g722/64k (6), g722/56k (7), g722/48k (8))',
+				'AudioTOS' => '184',
+				'AudioCOS' => '6',
+				'VideoTOS' => '136',
+				'VideoCOS' => '5',
+				'DNDFeatureEnabled' => 'yes',
+				'DNDStatus' => 'Disabled',
+				'DNDAction' => 'Reject',
+				'CanTransfer' => 'on',
+				'CanPark' => 'on',
+				'CanCFWDALL' => 'on',
+				'CanCFWBUSY' => 'off',
+				'CanCFWNOANSWER' => 'off',
+				'AllowRinginNotification' => 'no',
+				'PrivateSoftkey' => 'on',
+				'DtmfMode' => 'RFC2833',
+				'Nat' => '(Auto)Off',
+				'Videosupport' => 'no',
+				'DirectRTP' => 'off',
+				'BindAddress' => '[::ffff:10.15.15.205]:52869',
+				'ServerAddress' => '[::ffff:10.15.15.195]:60675',
+				'DenyPermit' => 'deny:0.0.0.0/0.0.0.0,permit:10.15.15.0/255.255.255.0,permit:127.0.0.0/255.255.255.0,',
+				'PermitHosts' => '',
+				'EarlyRTP' => 'Ringout',
+				'DeviceStateAcc' => 'Off Hook',
+				'LastUsedAccessory' => 'Handset',
+				'LastDialedNumber' => '',
+				'DefaultLineInstance' => '1',
+				'CustomBackgroundImage' => 'http://10.15.15.195:8088/static/strand.png',
+				'CustomRingTone' => '---',
+				'UsePlacedCalls' => 'on',
+				'PendingUpdate' => 'off',
+				'PendingDelete' => 'off',
+				'DirectedPickup' => 'on',
+				'PickupContext' => 'sccp (exists)',
+				'PickupModeAnswer' => 'on',
+				'allowConference' => 'on',
+				'confPlayGeneralAnnounce' => 'on',
+				'confPlayPartAnnounce' => 'on',
+				'confMuteOnEntry' => 'on',
+				'confMusicOnHoldClass' => 'default',
+				'confShowConflist' => 'on',
+				'conflistActive' => 'off',
+            ),
+            'SCCPDeviceButtonEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceButton',
+				'Id' => '1',
+				'Inst' => '1',
+				'TypeStr' => 'Line',
+				'Type' => '0',
+				'pendUpdt' => 'No',
+				'pendDel' => 'No',
+				'Default' => 'Yes',
+            ),
+            'SCCPDeviceLineEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceLine',
+				'Id' => '1',
+				'Name' => '98041',
+				'Suffix' => '',
+				'Label' => 'Phone 4 Line 1',
+				'CfwdType' => 'None',
+				'CfwdNumber' => '',
+            ),
+            'SCCPDeviceSpeeddialEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceSpeeddial',
+				'Id' => '3',
+				'Name' => '98011',
+				'Number' => '98011',
+				'Hint' => '98011@hints',
+			),
+			'SCCPDeviceFeatureEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceFeature',
+				'Id' => '8',
+				'Name' => 'call forwared',
+				'Options' => '500',
+				'Status' => '0',
+			),
+			'SCCPDeviceServiceURLEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceFeature',
+				'Id' => '8',
+				'Name' => 'Services',
+				'URL' => 'http://www.example.com/',
+			),
+			'SCCPDeviceStatisticsEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'DeviceStatistics',
+				'Type' => 'LAST',
+				'Calls' => '0',
+				'PcktSnt' => '0',
+				'PcktRcvd' => '0',
+				'Lost' => '0',
+				'Jitter' => '0',
+				'Latency' => '0',
+				'Quality' => '0.000000',
+				'avgQual' => '0.000000',
+				'meanQual' => '0.000000',
+				'maxQual' => '0.000000',
+				'rConceal' => '0.000000',
+				'sConceal' => '0',
+            ),
+            'SCCPVariablesEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Variable',
+            	'Name' => 'Test',
+            	'Value' => 'Something',
+            ),
+            'SCCPShowDeviceComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPShowDevice' => array(
+				'Keepalive' => 60,
+				'MWIHandsetLight' => false,
+				'SoftkeySupport' => true,
+				'BTemplateSupport' => true,
+				'LinesRegistered' => true,
+				'TimezoneOffset' => 0,
+				'Capabilities' => array(array('name'=>'slin16', 'value'=>25), array('name'=>'g722/64k','value'=>6), array('name'=>'ulaw/64k','value'=>4)),
+				'CodecsPreference' => array(array('name'=>'g722/64k', 'value'=>6), array('name'=>'g722/56k', 'value'=>7), array('name'=>'g722/48k', 'value'=>8)),
+				'AudioTOS' => 184,
+				'AudioCOS' => 6,
+				'VideoTOS' => 136,
+				'VideoCOS' => 5,
+				'DNDFeatureEnabled' => true,
+				'CanTransfer' => true,
+				'CanPark' => true,
+				'CanCFWDALL' => true,
+				'CanCFWBUSY' => false,
+				'CanCFWNOANSWER' => false,
+				'AllowRinginNotification' => false,
+				'PrivateSoftkey' => true,
+				'Videosupport' => false,
+				'DirectRTP' => false,
+				'DenyPermit' => array('deny'=>array('0.0.0.0/0.0.0.0'),'permit'=>array('10.15.15.0/255.255.255.0','127.0.0.0/255.255.255.0')),
+				'DefaultLineInstance' => 1,
+				'UsePlacedCalls' => true,
+				'PendingUpdate' => false,
+				'PendingDelete' => false,
+				'DirectedPickup' => true,
+				'PickupModeAnswer' => true,
+				'allowConference' => true,
+				'confPlayGeneralAnnounce' => true,
+				'confPlayPartAnnounce' => true,
+				'confMuteOnEntry' => true,
+				'confShowConflist' => true,
+				'conflistActive' => false,
+            ),
+            'SCCPDeviceButtonEntry' => array(
+            	'Id' => 1,
+            	'Inst' => 1,
+            	'Type' => 0,
+            	'pendUpdt' => false,
+            	'pendDel' => false,
+            	'Default' => true,
+            ),
+            'SCCPDeviceLineEntry' => array(
+				'Id' => 1,
+				'Suffix' => 0,
+            ),
+            'SCCPDeviceSpeeddialEntry' => array(
+				'Id' => 3,
+			),
+			'SCCPDeviceFeatureEntry' => array(
+				'Id' => 8,
+				'Status' => 0,
+			),
+			'SCCPDeviceServiceURLEntry' => array(
+				'Id' => 8,
+			),
+			'SCCPDeviceStatisticsEntry' => array(
+				'Calls' => 0,
+				'PcktSnd' => 0,
+				'PcktRcvd' => 0,
+				'Lost' => 0,
+				'Jitter' => 0,
+				'Latency' => 0,
+				'Quality' => 0.000000,
+				'avgQual' => 0.000000,
+				'meanQual' => 0.000000,
+				'maxQual' => 0.000000,
+				'rConceal' => 0.000000,
+				'sConceal' => 0,
+            ),
+            'SCCPShowDeviceComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+            'SCCPShowDevice' => array(
+            	'MACAddress' => 'DeviceName',
+            ),
+			'SCCPDeviceButtonEntry' => array(
+				'pendUpdt' => 'PendingUpdate',
+				'pendDel' => 'PendingDelete',
+			),
+			'SCCPDeviceStatisticsEntry' => array(
+				'PcktSnt' => 'PacketsSent',
+				'PcktRcvd' => 'PacketsReceived',
+				'Lost' => 'PacketsLost',
+				'avgQual' => 'AverageQuality',
+				'meanQual' => 'MeanQuality',
+				'maxQual' => 'MaxQuality',
+				'rConceal' => 'ReceivedConcealed',
+				'sConceal' => 'SentConcealed',
+            ),
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     * @expectedException \PAMI\Exception\PAMIException
+     */
+    public function cannot_showdevice_events_with_broken_denypermit()
+    {
+        $eventValues = array(
+            'SCCPShowDevice' => array(
+				'DenyPermit' => 'denny:0.0.0.0/0.0.0.0,permit:10.|ermit:127.0.0.0/255.255.255.0,',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPShowDevice' => array(
+				'DenyPermit' => array('deny'=>array('0.0.0.0/0.0.0.0'),'permit'=>array('10.15.15.0/255.255.255.0','127.0.0.0/255.255.255.0')),
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_showlines_events()
+    {
+        $eventValues = array(
+        	'SCCPLineEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Line',
+				'Exten' => '98011',
+				'SubscriptionNumber' => '',
+				'Label' => 'Diederik de Groot (98011)',
+				'Device' => 'SEP001B54CA499B',
+				'MWI' => 'OFF',
+				'ActiveChannels' => '1',
+				'ChannelState' => '--',
+				'CallType' => '',
+				'PartyName' => '',
+				'Capabilities' => '',
+        	),
+            'SCCPShowLinesComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+        	'SCCPLineEntry' => array(
+				'ActiveChannels' => 1,
+        	),
+            'SCCPShowLinesComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_showline_events()
+    {
+        $eventValues = array(
+            'SCCPShowLine' => array(
+				'Name' => '98011',
+				'Description' => 'chan-sccp.net',
+				'Label' => 'Diederik de Groot (98011)',
+				'ID' => '0005',
+				'Pin' => '9944',
+				'VoiceMailNumber' => '*998011',
+				'TransferToVoicemail' => '699',
+				'MeetMeEnabled' => 'on',
+				'MeetMeNumber' => '',
+				'MeetMeOptions' => 'qxd',
+				'Context' => 'sccp (exists)',
+				'Language' => 'nl',
+				'AccountCode' => '98011',
+				'Musicclass' => 'default',
+				'AmaFlags' => '0',
+				'CallGroup' => '1, 2',
+				'PickupGroup' => '1, 3',
+				'NamedCallGroup' => 'engineering,sales,netgroup,protgroup',
+				'NamedPickupGroup' => 'sales',
+				'ParkingLot' => 'default',
+				'CallerIDName' => 'Diederik de Groot (98011)',
+				'CallerIDNumber' => '98011',
+				'IncomingCallsLimit' => '3',
+				'ActiveChannelCount' => '0',
+				'SecDialtoneDigits' => '9',
+				'SecDialtone' => '0x22',
+				'EchoCancellation' => 'on',
+				'SilenceSuppression' => 'off',
+				'CanTransfer' => 'on',
+				'DNDAction' => 'Reject',
+				'IsRealtimeLine' => 'on',
+				'PendingDelete' => 'off',
+				'PendingUpdate' => 'off',
+				'RegistrationExtension' => '',
+				'RegistrationContext' => '',
+				'AdhocNumberAssigned' => 'on',
+				'MessageWaitingNew' => '0',
+				'MessageWaitingOld' => '0',
+			),
+            'SCCPAttachedDeviceEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'AttachedDevice',
+				'DeviceName' => 'SEP001B54CA499B',
+				'CfwdType' => 'Busy',
+				'CfwdNumber' => '1234',
+            ),
+            'SCCPMailboxEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Mailbox',
+				'mailbox' => '98011',
+				'context' => 'default',
+            ),
+            'SCCPVariablesEntry' => array(
+            	'Name' => 'Test',
+            	'Value' => 'Something',
+            ),
+            'SCCPShowLineComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPShowLine' => array(
+				'ID' => 5,
+				'Pin' => 9944,
+				'MeetMeEnabled' => true,
+				'AmaFlags' => 0,
+				'CallGroup' => array(1, 2),
+				'PickupGroup' => array(1, 3),
+				'NamedCallGroup' => array('engineering','sales','netgroup','protgroup'),
+				'NamedPickupGroup' => array('sales'),
+				'IncomingCallsLimit' => 3,
+				'ActiveChannelCount' => 0,
+				'SecDialtoneDigits' => 9,
+				'SecDialtone' => 34,
+				'EchoCancellation' => true,
+				'SilenceSuppression' => false,
+				'CanTransfer' => true,
+				'IsRealtimeLine' => true,
+				'PendingDelete' => false,
+				'PendingUpdate' => false,
+				'AdhocNumberAssigned' => true,
+				'MessageWaitingNew' => 0,
+				'MessageWaitingOld' => 0,
+			),
+            'SCCPShowLineComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_showchannels_events()
+    {
+        $eventValues = array(
+        	'SCCPChannelEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Channel',
+				'ID' => '1',
+				'Name' => 'SCCP/98011-00000001',
+				'LineName' => '98011',
+				'DeviceName' => 'SEP001B54CA499B',
+				'NumCalled' => '98031',
+				'PBXState' => 'Ring',
+				'SCCPState' => 'RINGOUT',
+				'ReadCodec' => 'alaw/64k',
+				'WriteCodec' => 'alaw/64k',
+				'RTPPeer' => '10.15.15.139:29312',
+				'Direct' => 'no',
+				'DTMFmode' => 'RFC2833',
+        	),
+            'SCCPVariablesEntry' => array(
+            	'Name' => 'Test',
+            	'Value' => 'Something',
+            ),
+            'SCCPShowChannelsComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+        	'SCCPChannelEntry' => array(
+				'ID' => 1,
+				'Direct' => false,
+        	),
+            'SCCPShowChannelsComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        	'SCCPChannelEntry' => array(
+        		'Direct' => 'DirectMedia',
+        	),
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_get_session_events()
+    {
+        $eventValues = array(
+            'SCCPSessionEntry' => array(
+				'ChannelType' => 'SCCP',
+				'ChannelObjectType' => 'Session',
+				'ActionID' => '1428150989.9115',
+				'Socket' => '18',
+				'IP' => '::ffff:10.15.15.114',
+				'Port' => '51139',
+				'KA' => '55',
+				'KAI' => '58',
+				'DeviceName' => 'SEP0024C4446974',
+				'State' => 'On Hook',
+				'Type' => 'Cisco 7962',
+				'RegState' => 'OK',
+				'Token' => 'No Token',
+            ),
+            'SCCPShowSessionsComplete' => array(
+            	'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPSessionEntry' => array (
+            	'Socket' => 18,
+            	'KA' => 55,
+            	'KAI' => 58,
+            ),
+            'SCCPShowSessionsComplete' => array(
+            	'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        	'SCCPSessionEntry' => array (
+				'KA' => 'KeepAlive',
+				'KAI' => 'KeepAliveInterval'
+			),
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+    }
+
+    /**
+     * @test
+     */
+   public function can_get_SCCPConference_events()
+    {
+        $eventValues = array(
+            'SCCPConferenceEntry' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'Conference',
+                'Id' => '100',
+                'Participants' => '1',
+                'Moderators' => '1',
+                'Announce' => 'Yes',
+                'MuteOnEntry' => 'Yes',
+            ),
+            'SCCPShowConferencesComplete' => array(
+                'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConferenceEntry' => array(
+                'Id' => 100,
+                'Participants' => 1,
+                'Moderators' => 1,
+                'Announce' => true,
+                'MuteOnEntry' => true,
+            ),
+            'SCCPShowConferencesComplete' => array(
+                'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPHintLineState_events()
+    {
+        $eventValues = array(
+            'SCCPHintLineStateEntry' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'HintLineState',
+                'LineName' => '98099',
+                'State' => 'ONHOOK',
+                'CallInfoNumber' => '',
+                'CallInfoName' => '',
+                'Direction' => 'INACTIVE',
+            ),
+            'SCCPShowHintLineStatesComplete' => array(
+                'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPShowHintLineStatesComplete' => array(
+                'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPHintSubscription_events()
+    {
+        $eventValues = array(
+            'SCCPHintSubscriptionEntry' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'HintSubscription',
+                'Exten' => '1234',
+                'Context' => 'hints',
+                'Hint' => 'SIP/1234',
+                'State' => 'CONGESTION',
+                'CallInfoNumber' => '',
+                'CallInfoName' => '',
+                'Direction' => '',
+                'Subs' => '1',
+            ),
+            'SCCPShowHintSubscriptionsComplete' => array(
+                'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPHintSubscriptionEntry' => array(
+                'Subs' => 1,
+            ),
+            'SCCPShowHintSubscriptionsComplete' => array(
+                'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPMailboxSubscriber_events()
+    {
+        $eventValues = array(
+            'SCCPMailboxSubscriberEntry' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'MailboxSubscriber',
+                'Mailbox' => '98041',
+                'LineName' => '98041',
+                'Context' => 'default',
+                'New' => '0',
+                'Old' => '0',
+                'Sub' => 'YES',
+            ),
+            'SCCPShowMWISubscriptionsComplete' => array(
+                'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPMailboxSubscriberEntry' => array(
+                'New' => 0,
+                'Old' => 0,
+                'Sub' => true,
+            ),
+            'SCCPShowMWISubscriptionsComplete' => array(
+                'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPSoftKeySet_events()
+    {
+        $eventValues = array(
+            'SCCPSoftKeySetEntry' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'SoftKeySet',
+                'Set' => 'default',
+                'Mode' => 'ONHOOK',
+                'Description' => 'On Hook',
+                'LblID' => '0',
+                'Label' => 'Redial',
+            ),
+            'SCCPShowSoftKeySetsComplete' => array(
+                'ListItems' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPSoftKeySetEntry' => array(
+                'LblID' => 0,
+            ),
+            'SCCPShowSoftKeySetsComplete' => array(
+                'ListItems' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_CallAnswered_events()
+    {
+        $eventValues = array(
+            'CallAnswered' => array(
+                'Channel' => 'SCCP/00112244-100',
+                'SCCPLine' => '98011',
+                'SCCPDevice' => 'SEP0011223344',
+                'Uniqueid' => '12345678',
+                'CallingPartyNumber' => '666',
+                'CallingPartyName' => 'His Majesty',
+                'originalCallingParty' => 'The One',
+                'lastRedirectingParty' => 'Someone',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'CallAnswered' => array(
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_DeviceStatus_events()
+    {
+        $eventValues = array(
+            'DeviceStatus' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'DeviceStatus',
+                'DeviceStatus' => 'REGISTERED',
+                'SCCPDevice' => 'SEP0011223344',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'DeviceStatus' => array(
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_DND_events()
+    {
+        $eventValues = array(
+            'DND' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'Device',
+                'Feature' => 'Do not disturb',
+                'Status' => 'On',
+                'SCCPDevice' => 'SEP0011223344',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'DND' => array(
+            	'Status' => true,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_CallForward_events()
+    {
+        $eventValues = array(
+            'CallForward' => array(
+                'ChannelType' => 'SCCP',
+                'ChannelObjectType' => 'Device',
+                'Feature' => 'Cfwd',
+                'Status' => 'On',
+                'Extension' => '1234',
+                'SCCPLine' => '98011',
+                'SCCPDevice' => 'SEP0011223344',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'CallForward' => array(
+            	'Status' => true,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfEnd_events()
+    {
+        $eventValues = array(
+            'SCCPConfEnd' => array(
+                'ConfId' => '100',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfEnd' => array(
+                'ConfId' => 100,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfLeave_events()
+    {
+        $eventValues = array(
+            'SCCPConfLeave' => array(
+                'ConfId' => '111',
+                'PartId' => '1',
+                'Channel' => 'SCCP/00112244-100',
+                'Uniqueid' => '12345678',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfLeave' => array(
+                'ConfId' => 111,
+                'PartId' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfStart_events()
+    {
+        $eventValues = array(
+            'SCCPConfStart' => array(
+                'ConfId' => '100',
+                'SCCPDevice' => 'SEP0011223344',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfStart' => array(
+                'ConfId' => 100,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfEntered_events()
+    {
+        $eventValues = array(
+            'SCCPConfEntered' => array(
+                'ConfId' => '100',
+                'PartId' => '1',
+                'Channel' => 'SCCP/00112244-100',
+                'Uniqueid' => '12345678',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfEntered' => array(
+                'ConfId' => 100,
+                'PartId' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfLeft_events()
+    {
+        $eventValues = array(
+            'SCCPConfLeft' => array(
+                'ConfId' => '100',
+                'PartId' => '1',
+                'Channel' => 'SCCP/00112244-100',
+                'Uniqueid' => '12345678',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfLeft' => array(
+                'ConfId' => 100,
+                'PartId' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfStarted_events()
+    {
+        $eventValues = array(
+            'SCCPConfStarted' => array(
+                'ConfId' => '100',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfStarted' => array(
+                'ConfId' => 100,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfParticipantKicked_events()
+    {
+        $eventValues = array(
+            'SCCPConfParticipantKicked' => array(
+                'ConfId' => '100',
+                'PartId' => '1',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfParticipantKicked' => array(
+                'ConfId' => 100,
+                'PartId' => 1,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfLock_events()
+    {
+        $eventValues = array(
+            'SCCPConfLock' => array(
+                'ConfId' => '100',
+                'Enabled' => 'Yes',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfLock' => array(
+                'ConfId' => 100,
+                'Enabled' => true,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfParticipantMute_events()
+    {
+        $eventValues = array(
+            'SCCPConfParticipantMute' => array(
+                'ConfId' => '100',
+                'PartId' => '1',
+                'Mute' => 'Yes',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfParticipantMute' => array(
+                'ConfId' => 100,
+                'PartId' => 1,
+                'Mute' => true,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    /**
+     * @test
+     */
+    public function can_get_SCCPConfParticipantPromotion_events()
+    {
+        $eventValues = array(
+            'SCCPConfParticipantPromotion' => array(
+                'ConfId' => '100',
+                'PartId' => '1',
+                'Moderator' => 'Yes',
+            ),
+        );
+        $eventTranslatedValues = array(
+            'SCCPConfParticipantPromotion' => array(
+                'ConfId' => 100,
+                'PartId' => 1,
+                'Moderator' => true,
+            ),
+        );
+        $eventGetters = array(
+        );
+        foreach (array_keys($eventValues) as $eventName) {
+            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+        }
+	}
+
+    private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
+    {
+        global $mock_stream_socket_client;
+        global $mock_stream_set_blocking;
+        global $mockTime;
+        global $standardAMIStart;
+        $eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
+        $mockTime = true;
+        $mock_stream_socket_client = true;
+        $mock_stream_set_blocking = true;
+        $options = array(
+            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
+        	'host' => '2.3.4.5',
+            'scheme' => 'tcp://',
+        	'port' => 9999,
+        	'username' => 'asd',
+        	'secret' => 'asd',
+            'connect_timeout' => 10,
+        	'read_timeout' => 10
+        );
+        $write = array(
+        	"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
+        );
+        setFgetsMock($standardAMIStart, $write);
+        $client = new \PAMI\Client\Impl\ClientImpl($options);
+        $client->registerEventListener(new SomeListenerClass);
+	    $client->open();
+	    $message = array();
+	    $message[] = 'Event: ' . $eventName;
+	    foreach ($values as $key => $value) {
+	        $message[] = $key . ': ' . $value;
+	    }
+	    $message[] = '';
+	    setFgetsMock($message, $message);
+	    for($i = 0; $i < count($message); $i++) {
+	        $client->process();
+	    }
+	    $event = SomeListenerClass::$event;
+        $this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
+        foreach ($values as $key => $value) {
+            if (isset($getters[$eventName][$key])) {
+                $methodName = 'get' . $getters[$eventName][$key];
+            } else {
+                $methodName = 'get' . $key;
+            }
+            if (isset($translatedValues[$eventName][$key])) {
+                $value = $translatedValues[$eventName][$key];
+            }
+            $this->assertEquals($event->$methodName(), $value, "Event: '$eventName'->'$methodName' to retrieve Key: '$key', returned Value: '". var_dump($event->$methodName()) ."' instead of expected: '" . var_dump($value) . "'");
+        }
+    }
+}
+}


### PR DESCRIPTION
Added a currently known Actions and Events to deal with chan-sccp-b AMI
Based on the ResponseFactory branch (But not 100% down to it yet).

Example files using ResponseFactory specifics
SCCPConfigMetaDataAction
SCCPShowGlobalSettingsAction
SCCPShowChannels

Simple Tests are done.
More Extensive Tests (TableStart/TableEnd, moving Events into => Tables[tablename][]) will be have to added.

Bit of cleanup is still required, waiting for approval of the ResponseFactory