### PR TITLE
Response factory

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -38,6 +38,7 @@ use PAMI\Message\Action\LogoffAction;
 use PAMI\Message\Response\ResponseMessage;
 use PAMI\Message\Event\EventMessage;
 use PAMI\Message\Event\Factory\Impl\EventFactoryImpl;
+use PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl;
 use PAMI\Listener\IEventListener;
 use PAMI\Client\Exception\ClientException;
 use PAMI\Client\IClient;
@@ -105,6 +106,12 @@ class ClientImpl implements IClient
 	private $_eventFactory;
 
 	/**
+	 * Event factory.
+	 * @var EventFactoryImpl
+	 */
+	private $_responseFactory;
+
+	/**
 	 * R/W timeout, in milliseconds.
 	 * @var integer
 	 */
@@ -153,6 +160,16 @@ class ClientImpl implements IClient
 	 * @var string
 	 */
 	private $_lastActionId;
+
+	/**
+	 * @var string
+	 */
+	private $_lastRequestedResponseHandler;
+
+	/**
+	 * @object class
+	 */
+	private $_lastActionClass;
 
 	/**
 	 * Opens a tcp connection to ami.
@@ -252,7 +269,7 @@ class ClientImpl implements IClient
 	 * your own application in order to continue reading events and responses
 	 * from ami. 
 	 */
-	public function process()
+	public function process($outgoingMessageClass=false)
 	{
 	    $msgs = $this->getMessages();
 	    foreach ($msgs as $aMsg) {
@@ -339,7 +356,7 @@ class ClientImpl implements IClient
 	 */
 	private function _messageToResponse($msg)
 	{
-        $response = new ResponseMessage($msg);
+		$response = $this->_responseFactory->createFromRaw($msg, $this->_lastActionClass, $this->_lastRequestedResponseHandler);
 	    $actionId = $response->getActionId();
 	    if ($actionId === null) {
 	        $actionId = $this->_lastActionId;
@@ -357,7 +374,9 @@ class ClientImpl implements IClient
 	 */
 	private function _messageToEvent($msg)
 	{
-        return $this->_eventFactory->createFromRaw($msg);
+		$event;
+		$event = $this->_eventFactory->createFromRaw($msg);
+        return $event;
 	}
 
 	/**
@@ -400,7 +419,12 @@ class ClientImpl implements IClient
 	        	'------ Sending: ------ ' . "\n" . $messageToSend . '----------'
 	        );
         }
-	    $this->_lastActionId = $message->getActionId();
+		// If there are multiple outgoing messages in flight, we might have to add this information to a queue instead
+		//$this->_outgoingQueue[$this->_lastActionId] == array('ResponseHandler' => $message->getResponseHandler()); // push
+		$this->_lastActionId = $message->getActionId();
+		$this->_lastRequestedResponseHandler = $message->getResponseHandler();
+		$this->_lastActionClass = $message;
+
 	    if (@fwrite($this->_socket, $messageToSend) < $length) {
     	    throw new ClientException('Could not send message');
 		}
@@ -455,7 +479,8 @@ class ClientImpl implements IClient
 		$this->_rTimeout = isset($options['read_timeout']) ? isset($options['read_timeout']) : 1;
 		$this->_scheme = isset($options['scheme']) ? $options['scheme'] : 'tcp://';
 		$this->_eventListeners = array();
-		$this->_eventFactory = new EventFactoryImpl();
+		$this->_eventFactory = new EventFactoryImpl(\Logger::getLogger('EventFactory'));
+		$this->_responseFactory = new ResponseFactoryImpl(\Logger::getLogger('ResponseFactory'));
 		$this->_incomingQueue = array();
 		$this->_lastActionId = false;
 	}

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -231,21 +231,20 @@ class ClientImpl implements IClient
 	{
 	    $msgs = array();
 	    // Read something.
-	    $read = @fread($this->_socket, 65535);
-	    if ($read === false || @feof($this->_socket)) {
-	        throw new ClientException('Error reading');
-	    }
-	    $this->_currentProcessingMessage .= $read;
-	    // If we have a complete message, then return it. Save the rest for
-	    // later.
-	    while (($marker = strpos($this->_currentProcessingMessage, Message::EOM))) {
-    	    $msg = substr($this->_currentProcessingMessage, 0, $marker);
-    	    $this->_currentProcessingMessage = substr(
-    	        $this->_currentProcessingMessage, $marker + strlen(Message::EOM)
-    	    );
-    	    $msgs[] = $msg;
-	    }
-	    return $msgs;
+		$read = @fread($this->_socket, 8192);
+		if ($read === false || @feof($this->_socket)) {
+			throw new ClientException('Error During Socket Read');
+		}
+		$this->_currentProcessingMessage .= $read;
+		// If we have a complete message, then return it. Save the rest for later.
+		while (($marker = strpos($this->_currentProcessingMessage, Message::EOM))) {
+		   $msg = substr($this->_currentProcessingMessage, 0, $marker);
+		   $this->_currentProcessingMessage = substr(
+			   $this->_currentProcessingMessage, $marker + strlen(Message::EOM)
+		   );
+		   $msgs[] = $msg;
+		}
+		return $msgs;
 	}
 
 	/**
@@ -404,21 +403,22 @@ class ClientImpl implements IClient
 	    $this->_lastActionId = $message->getActionId();
 	    if (@fwrite($this->_socket, $messageToSend) < $length) {
     	    throw new ClientException('Could not send message');
-	    }
-	    $read = 0;
-	    while($read <= $this->_rTimeout) {
-	        $this->process();
-	        $response = $this->getRelated($message);
-	        if ($response != false) {
-	            $this->_lastActionId = false;
-	            return $response;
-	        }
-	        usleep(1000); // 1ms delay
-	        if ($this->_rTimeout > 0) {
-	            $read++;
-	        }
-	    }
-	    throw new ClientException('Read timeout');
+		}
+		while (1) {
+			@stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
+			$this->process();
+			$info = @stream_get_meta_data($this->_socket);
+			if ($info['timed_out'] == false) {
+				$response = $this->getRelated($message);
+				if ($response != false) {
+					$this->_lastActionId = false;
+					return $response;
+				}
+			} else {
+				break;
+			}
+		}
+		throw new ClientException("Read waittime: " . ($this->_rTimeout) . " exceeded (timeout).\n");
 	}
 
 	/**
@@ -452,7 +452,7 @@ class ClientImpl implements IClient
 		$this->_user = $options['username'];
 		$this->_pass = $options['secret'];
 		$this->_cTimeout = $options['connect_timeout'];
-		$this->_rTimeout = $options['read_timeout'];
+		$this->_rTimeout = isset($options['read_timeout']) ? isset($options['read_timeout']) : 1;
 		$this->_scheme = isset($options['scheme']) ? $options['scheme'] : 'tcp://';
 		$this->_eventListeners = array();
 		$this->_eventFactory = new EventFactoryImpl();

--- a/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/mg/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -33,6 +33,7 @@ namespace PAMI\Message\Event\Factory\Impl;
 use PAMI\Message\Event\EventMessage;
 use PAMI\Message\Event\UnknownEvent;
 use PAMI\Message\Message;
+use PAMI\Exception\PAMIException;
 
 /**
  * This factory knows which event to return according to a given raw message
@@ -49,6 +50,8 @@ use PAMI\Message\Message;
  */
 class EventFactoryImpl
 {
+	private $_logger;
+
     /**
      * This is our factory method.
      *
@@ -56,7 +59,8 @@ class EventFactoryImpl
      *
      * @return EventMessage
      */
-    public static function createFromRaw($message)
+//    public static function createFromRaw($message)
+    public function createFromRaw($message)
     {
         $eventStart = strpos($message, 'Event: ') + 7;
 /*
@@ -70,10 +74,12 @@ class EventFactoryImpl
         }
         $name = substr($message, $eventStart, $eventEnd - $eventStart);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
-        if (class_exists($className, true)) {
-            return new $className($message);
-        }
-	    return new UnknownEvent($message);
+		if (class_exists($className, true)) {
+			if ($this->_logger->isDebugEnabled()) $this->_logger->debug("Created: " . $className . "\n");
+			return new $className($message);
+		}
+ 		if ($this->_logger->isDebugEnabled()) $this->_logger->debug("Created: " . '\\PAMI\\Message\\Event\\UnknownEvent' . "\n");
+		return new UnknownEvent($message);
     }
 
     /**
@@ -81,7 +87,9 @@ class EventFactoryImpl
      *
      * @return void
      */
-    public function __construct()
+    public function __construct($logger)
     {
+		$this->_logger = $logger ? $logger : \Logger::getLogger(__CLASS__);
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('------ Event Factory Created: ------ ' . "\n");
     }
 }

--- a/src/mg/PAMI/Message/IncomingMessage.php
+++ b/src/mg/PAMI/Message/IncomingMessage.php
@@ -28,6 +28,7 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
 /**
  * A generic incoming message.
  *
@@ -97,7 +98,11 @@ abstract class IncomingMessage extends Message
             $name = strtolower(trim($content[0]));
             unset($content[0]);
             $value = isset($content[1]) ? trim(implode(':', $content)) : '';
-            $this->setKey($name, $value);
+			try {
+				$this->setSanitizedKey($name, $value);
+			} catch (PAMIException $e) {
+				throw new PAMIException("Error: '" . $e . "'\n Dump RawContent:\n"  . $this->rawContent ."\n");
+			}
         }
     }
 }

--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -28,6 +28,7 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
 /**
  * A generic ami message, in-or-outbound.
  *
@@ -129,6 +130,40 @@ abstract class Message
 	}
 
 	/**
+	 * Sanitize incoming value
+	 *
+	 * @param string $value Key value.
+	 *
+	 * @return typed and sanitized value
+	 */
+	protected function sanitizeInput($value)
+	{
+		if (!isset($value) || $value === NULL || strlen($value) == 0) {
+			return NULL;
+		} else if (is_numeric($value)) {
+			if (filter_var($value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX | FILTER_FLAG_ALLOW_OCTAL)) {
+				return intval($value, 0);
+			} else if (filter_var($value, FILTER_VALIDATE_FLOAT, FILTER_FLAG_ALLOW_FRACTION | FILTER_FLAG_ALLOW_THOUSAND | FILTER_FLAG_ALLOW_SCIENTIFIC)) {
+				return (float)$value;
+			} else {
+				return (double)$value;
+			}
+		} else if (is_string($value)) {
+			if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)) {
+				return (boolean)$value;
+			} else if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
+				return (string)$value;
+			} else if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
+				return (string)htmlspecialchars($value, ENT_QUOTES);
+			} else {
+				throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");
+			}
+		} else {
+			throw new PAMIException("Don't know how to convert: '" . $value . "'\n");
+		}
+	}
+
+	/**
 	 * Adds a variable to this message.
 	 *
 	 * @param string $key   Key name (i.e: Action).
@@ -138,8 +173,26 @@ abstract class Message
 	 */
 	protected function setKey($key, $value)
 	{
-	    $key = strtolower((string)$key);
-	    $this->keys[$key] = (string)$value;
+		$key = strtolower((string)$key);
+		$this->keys[$key] = (string)$value;
+	}
+
+	/**
+	 * Adds a variable to this message after sanitizing it first.
+	 *
+	 * @param string $key   Key name (i.e: Action).
+	 * @param string $value Key value.
+	 *
+	 * @return void
+	 */
+	protected function setSanitizedKey($key, $value)
+	{
+		$key = strtolower((string)$key);
+		if ($key === 'actionid') {
+			$this->keys[$key] = (string)$this->sanitizeInput($value);
+		} else {
+			$this->keys[$key] = $this->sanitizeInput($value);
+		}
 	}
 
 	/**
@@ -155,7 +208,22 @@ abstract class Message
 	    if (!isset($this->keys[$key])) {
 		    return null;
 		}
-		return (string)$this->keys[$key];
+		//return (string)$this->keys[$key];
+		return $this->keys[$key];
+	}
+
+	/**
+	 * Returns a key by name as boolean.
+	 *
+	 * @param string $key Key name (i.e: Action).
+	 *
+	 * @return boolean
+	 */
+	public function getBoolKey($key)
+	{
+		$val = $this->getKey($key);
+		$boolval = ( is_string($val) ? filter_var($val, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : (bool) $val );
+		return ( $boolval===null ? false : $boolval );
 	}
 
 	/**

--- a/src/mg/PAMI/Message/OutgoingMessage.php
+++ b/src/mg/PAMI/Message/OutgoingMessage.php
@@ -28,6 +28,8 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
+
 /**
  * A generic outgoing message.
  *
@@ -41,4 +43,44 @@ namespace PAMI\Message;
  */
 abstract class OutgoingMessage extends Message
 {
+	/**
+	 * String of the Class name to handle the Reponse to this Message
+	 * @var string
+	 */
+	private $_responseHandler;
+
+	/**
+	 * Returns '_responseHandler'.
+	 *
+	 * @return string
+	 */
+	public function getResponseHandler()
+	{
+		if (strlen($this->_responseHandler) > 0) {
+			//throw new PAMIException('Hier:' . $this->_responseHandler);
+			return (string)$this->_responseHandler;
+		} else {
+			return "";
+		}
+	}
+
+	/**
+	 * Set '_responseHandler'.
+	 *
+	 * @return void
+	 * @throws if class cannot be found or strlen($responseHandler) == 0
+	 */
+	public function setResponseHandler($responseHandler)
+	{
+		if (0 == strlen($responseHandler)) {
+			throw new PAMIException('ResponseHandler cannot be empty.');
+		}
+
+		$className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+		if (class_exists($className, true)) {
+			$this->_responseHandler = $responseHandler;
+		} else {
+			throw new PAMIException('ResponseHandler could not be found.');
+		}
+	}
 }

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * This factory knows which response to return according to a given raw message
+ * from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response\Factory\Impl;
+
+use PAMI\Exception\PAMIException;
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Message\Response\GenericResponse;
+use PAMI\Message\Message;
+
+/**
+ * This factory knows which reponse handler to return according to a given raw message from ami,
+ * the outgoingMessageClass and responseHandler requested by the Action
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ResponseFactoryImpl
+{
+	private $_logger;
+	/**
+	 * This is our factory method.
+	 *
+	 * @param string $message Literal message as received from ami.
+	 * @param string $requestingaction
+	 * @param string $responseHandler
+	 *
+	 * @return EventMessage
+	 */
+	//public static function createFromRaw($message, $requestingaction = false, $responseHandler = false)
+	public function createFromRaw($message, $requestingaction = false, $responseHandler = false)
+	{
+		$responseclass = '\\PAMI\\Message\\Response\\GenericResponse';
+
+		$_className = false;
+		if ($responseHandler != false) {
+			$_className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+		} else if ($requestingaction != false) {
+			$_className = '\\PAMI\\Message\\Response\\' . substr(get_class($requestingaction), 20, -6) . 'Response';
+		}
+		if ($_className) {
+			if (class_exists($_className, true)) {
+				$responseclass = $_className;
+			} else if ($responseHandler != false){
+				throw new PAMIException('Response Class ' . $_className . '  requested via responseHandler, could not be found');
+			}
+		}
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('Created: ' . $responseclass . "\n");
+		return new $responseclass($message);
+	}
+
+	/**
+	 * Constructor. Nothing to see here, move along.
+	 *
+	 * @return void
+	 */
+//    public function __construct($logger)
+//    {
+//        $this->_logger = $logger;
+    public function __construct($logger)
+    {
+        $this->_logger = $logger ? $logger : \Logger::getLogger(__CLASS__);
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('------ Response Factory Created: ------ ' . "\n");
+    }
+}

--- a/src/mg/PAMI/Message/Response/GenericResponse.php
+++ b/src/mg/PAMI/Message/Response/GenericResponse.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+//use PAMI\Message\Message;
+//use PAMI\Message\IncomingMessage;
+//use PAMI\Message\Event\EventMessage;
+use PAMI\Message\Response\ResponseMessage;
+//use PAMI\Exception\PAMIException;
+
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class GenericResponse extends ResponseMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+}

--- a/src/mg/PAMI/Message/Response/ResponseMessage.php
+++ b/src/mg/PAMI/Message/Response/ResponseMessage.php
@@ -32,6 +32,7 @@ namespace PAMI\Message\Response;
 use PAMI\Message\Message;
 use PAMI\Message\IncomingMessage;
 use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
 
 /**
  * A generic response message from ami.
@@ -45,19 +46,19 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ResponseMessage extends IncomingMessage
+abstract class ResponseMessage extends IncomingMessage
 {
     /**
      * Child events.
      * @var EventMessage[]
      */
-    private $_events;
+    protected $_events;
 
     /**
      * Is this response completed? (with all its events).
      * @var boolean
      */
-    private $_completed;
+    protected $_completed;
 
     /**
      * Serialize function.

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -864,7 +864,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
     {
         $now = time();
         $action = new \PAMI\Message\Action\LoginAction('a', 'b');
-        $this->assertEquals($now, $action->getCreatedDate());
+        $this->assertGreaterThanOrEqual($now, $action->getCreatedDate());
         $action->setVariable('variable', 'value');
         $this->assertEquals($action->getVariable('variable'), 'value');
         $this->assertNull($action->getVariable('variable2'));

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -39,6 +39,8 @@ namespace {
     $mockFgets = false;
     $mockFgetsCount = 0;
     $mockFreadReturn = false;
+    $mock_stream_timeout = false;
+    $mockRTimeout = 0;
     $standardAMIStart = array(
    		'Asterisk Call Manager/1.1',
    		'Response: Success',
@@ -91,14 +93,30 @@ namespace PAMI\Client\Impl {
     function stream_socket_shutdown() {
         return true;
     }
-    function stream_set_blocking() {
-        global $mock_stream_set_blocking;
-        if (isset($mock_stream_set_blocking) && $mock_stream_set_blocking === true) {
-            return true;
-        } else {
-            return call_user_func_array('\stream_set_blocking', func_get_args());
-        }
-    }
+	function stream_set_blocking() {
+		global $mock_stream_set_blocking;
+		if (isset($mock_stream_set_blocking) && $mock_stream_set_blocking === true) {
+			return true;
+		} else {
+			return call_user_func_array('\stream_set_blocking', func_get_args());
+		}
+	}
+	function stream_set_timeout() {
+		global $mockRTimeout;
+		$args = func_get_args();
+		$mockRTimeout = $args[1];
+		return true;
+	}
+	function stream_get_meta_data() {
+		global $mockRTimeout;
+		global $mock_stream_timeout;
+		if (isset($mock_stream_timeout) && $mock_stream_timeout === true) {
+			sleep($mockRTimeout);
+			return array('timed_out' => true);
+		} else {
+			return call_user_func_array('\stream_get_meta_data', func_get_args());
+		}
+	}
     function fwrite() {
         global $mockFwrite;
         global $mockFwriteCount;
@@ -160,6 +178,7 @@ namespace PAMI\Client\Impl {
             return call_user_func_array('\fread', func_get_args());
         }
     }
+
     function setFgetsMock(array $readValues, $writeValues)
     {
         global $mockFgets;
@@ -639,11 +658,13 @@ class Test_Client extends \PHPUnit_Framework_TestCase
     {
         global $mock_stream_socket_client;
         global $mock_stream_set_blocking;
+        global $mock_stream_timeout;
         global $mockTime;
         global $standardAMIStart;
         $mockTime = true;
         $mock_stream_socket_client = true;
         $mock_stream_set_blocking = true;
+        $mock_stream_timeout = true;
         $options = array(
             'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
         	'host' => '2.3.4.5',
@@ -651,7 +672,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
         	'port' => 9999,
         	'username' => 'asd',
         	'secret' => 'asd',
-            'connect_timeout' => 10,
+            'connect_timeout' => 3,
         	'read_timeout' => 1
         );
         $write = array(
@@ -663,7 +684,7 @@ class Test_Client extends \PHPUnit_Framework_TestCase
         setFgetsMock(array(10, 4), $write);
         $start = \time();
         $client->send(new \PAMI\Message\Action\LoginAction('asd', 'asd'));
-        $this->assertEquals(\time() - $start, 10);
+        $this->assertEquals(\time() - $start, 3);
     }
     /**
      * @test

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -42,866 +42,862 @@ namespace PAMI\Client\Impl {
  */
 class Test_Events extends \PHPUnit_Framework_TestCase
 {
-    private $_properties = array();
+	private $_properties = array();
 
-    public function setUp()
-    {
-        $this->_properties = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
-        );
-    }
-    /**
-     * @test
-     */
-    public function can_report_events()
-    {
-        $eventNames = array(
-            'AsyncAGI', 'AGIExec', 'VarSet', 'Unlink', 'vgsm_sms_rx', 'vgsm_net_state',
-            'vgsm_me_state', 'DTMF', 'Bridge', 'VoicemailUserEntryComplete',
-            'StatusComplete', 'ParkedCallsComplete', 'DBGetResponse',
-            'VoicemailUserEntry', 'Transfer', 'Status', 'ShowDialPlanComplete',
-            'Rename', 'RegistrationsComplete', 'RTPSenderStat', 'RTPReceiverStat',
-            'RTCPSent', 'RTCPReceiverStat', 'RTCPReceived', 'QueueSummaryComplete',
-            'QueueStatusComplete', 'DAHDIShowChannelsComplete', 'QueueSummary',
-            'QueueParams', 'QueueMemberStatus', 'QueueMemberRemoved',
-            'QueueMemberPaused', 'QueueMember', 'QueueMemberAdded', 'PeerlistComplete',
-            'PeerStatus', 'PeerEntry', 'OriginateResponse', 'Newstate', 'Newexten',
-            'Newchannel', 'NewCallerid', 'NewAccountCode', 'MusicOnHold',
-            'MessageWaiting', 'Masquerade', 'ListDialplan', 'Leave', 'Join',
-            'Hold', 'Hangup', 'ExtensionStatus', 'Dial', 'DAHDIShowChannels',
-            'CoreShowChannelsComplete', 'CoreShowChannel', 'ChannelUpdate',
-            'Agents', 'AgentsComplete', 'Agentlogoff', 'Agentlogin', 'AgentConnect',
-            'DongleSMSStatus', 'FullyBooted', 'DongleShowDevicesComplete', 'DongleDeviceEntry',
-            'DongleNewUSSDBase64', 'DongleNewUSSD', 'DongleUSSDStatus', 'DongleNewCUSD',
-            'DongleStatus', 'CEL', 'JabberEvent', 'Registry', 'UserEvent',
-            'ParkedCall', 'UnParkedCall', 'Link'
-        );
-        $eventTranslatedValues = array(
-            'QueueMemberStatus' => array(
-                'Paused' => true
-            ),
-            'QueueMemberPaused' => array(
-                'Paused' => true
-            ),
-            'QueueMember' => array(
-                'Paused' => true
-            ),
-            'QueueMemberAdded' => array(
-                'Paused' => true
-            ),
-        );
-        $eventValues = array(
-            'UserEvent' => array(
-                'Privilege' => 'Privilege',
-                'UniqueID' => 'UniqueID',
-                'UserEvent' => 'UserEvent'
-            ),
-            'Registry' => array(
-                'Channel' => 'Channel',
-                'Domain' => 'Domain',
-                'Status' => 'Status'
-            ),
-            'JabberEvent' => array(
-                'Privilege' => 'Privilege',
-                'Account' => 'Account',
-                'Packet' => 'Packet'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Env',
-                'Channel' => 'Channel',
-                'CommandId' => 'CommandId',
-                'Privilege' => 'Privilege',
-                'SubEvent' => 'SubEvent',
-                'Result' => 'Result'
-            ),
-            'FullyBooted' => array(),
-            'DongleUSSDStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-             ),
-        	'DongleNewUSSDBase64' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-        	'DongleNewCUSD' => array(
-                'Device' => 'Device',
-                'Message' => 'Message',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleNewUSSD' => array(
-                'Device' => 'Device',
-                'LineCount' => 'LineCount',
-                'Privilege' => 'Privilege'
-            ),
-            'DongleDeviceEntry' => array(
-                'Device' => 'Device',
-                'AudioSetting' => 'AudioSetting',
-                'DataSetting' => 'DataSetting',
-                'IMEISetting' => 'IMEISetting',
-                'IMSISetting' => 'IMSISetting',
-                'ChannelLanguage' => 'ChannelLanguage',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Group' => 'Group',
-                'RXGain' => 'RXGain',
-                'TXGain' => 'TXGain',
-                'U2DIAG' => 'U2DIAG',
-                'UseCallingPres' => 'UseCallingPres',
-                'DefaultCallingPres' => 'DefaultCallingPres',
-                'AutoDeleteSMS' => 'AutoDeleteSMS',
-                'DisableSMS' => 'DisableSMS',
-                'ResetDongle' => 'ResetDongle',
-                'SMSPDU' => 'SMSPDU',
-                'CallWaitingSetting' => 'CallWaitingSetting',
-                'DTMF' => 'DTMF',
-                'MinimalDTMFGap' => 'MinimalDTMFGap',
-                'MinimalDTMFDuration' => 'MinimalDTMFDuration',
-                'MinimalDTMFInterval' => 'MinimalDTMFInterval',
-                'State' => 'State',
-                'AudioState' => 'AudioState',
-                'DataState' => 'DataState',
-                'Voice' => 'Voice',
-                'SMS' => 'SMS',
-                'Manufacturer' => 'Manufacturer',
-                'Model' => 'Model',
-                'Firmware' => 'Firmware',
-                'IMEIState' => 'IMEIState',
-                'IMSIState' => 'IMSIState',
-                'GSMRegistrationStatus' => 'GSMRegistrationStatus',
-                'RSSI' => 'RSSI',
-                'Mode' => 'Mode',
-                'Submode' => 'Submode',
-                'ProviderName' => 'ProviderName',
-                'LocationAreaCode' => 'LocationAreaCode',
-                'CellID' => 'CellID',
-                'SubscriberNumber' => 'SubscriberNumber',
-                'SMSServiceCenter' => 'SMSServiceCenter',
-                'UseUCS2Encoding' => 'UseUCS2Encoding',
-                'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
-                'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
-                'TasksInQueue' => 'TasksInQueue',
-                'CommandsInQueue' => 'CommandsInQueue',
-                'CallWaitingState' => 'CallWaitingState',
-                'CurrentDeviceState' => 'CurrentDeviceState',
-                'DesiredDeviceState' => 'DesiredDeviceState',
-                'CallsChannels' => 'CallsChannels',
-                'Active' => 'Active',
-                'Held' => 'Held',
-                'Dialing' => 'Dialing',
-                'Alerting' => 'Alerting',
-                'Incoming' => 'Incoming',
-                'Waiting' => 'Waiting',
-                'Releasing' => 'Releasing',
-                'Initializing' => 'Initializing'
-        	),
-        	'DongleShowDevicesComplete' => array('ListItems' => 'items'),
-            'DongleSMSStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Id' => 'Id',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'DongleStatus' => array(
-                'Privilege' => 'Privilege',
-        		'Device' => 'Device',
-                'Status' => 'Status'
-            ),
-            'AgentConnect' => array(
-                'HoldTime' => 'HoldTime',
-                'Privilege' => 'Privilege',
-                'BridgedChannel' => 'BridgedChannel',
-                'RingTime' => 'RingTime',
-                'Member' => 'Member',
-                'MemberName' => 'MemberName',
-                'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Queue' => 'Queue'
-            ),
-            'Agentlogoff' => array(
-                'Logintime' => 'Logintime',
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-            ),
-            'Agentlogin' => array(
-                'UniqueID' => 'UniqueID',
-                'Agent' => 'Agent',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-            ),
-            'AgentsComplete' => array(),
-            'Agents' => array(
-                'TalkingToChannel' => 'TalkingToChannel',
-                'TalkingTo' => 'TalkingTo',
-                'LoggedInTime' => 'LoggedInTime',
-                'LoggedInChan' => 'LoggedInChan',
-                'Name' => 'Name',
-                'Status' => 'Status',
-                'Agent' => 'Agent'
-            ),
-            'ChannelUpdate' => array(
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'ChannelType' => 'ChannelType',
-        		'UniqueID' => 'UniqueID',
-                'SIPfullcontact' => 'SIPfullcontact',
-                'SIPcallid' => 'SIPcallid'
-            ),
-            'CoreShowChannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'AccountCode' => 'AccountCode',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'CallerIDNum' => 'CallerIDNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Duration' => 'Duration',
-            ),
-            'DAHDIShowChannels' => array(
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Alarm' => 'Alarm',
-                'DND' => 'DND',
-                'SignallingCode' => 'SignallingCode',
-                'Signalling' => 'Signalling'
-            ),
-            'Dial' => array(
-                'Privilege' => 'Privilege',
-                'Destination' => 'Destination',
-                'SubEvent' => 'SubEvent',
-        		'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-        		'DialStatus' => 'DialStatus',
-                'DialString' => 'DialString',
-        		'UniqueID' => 'UniqueID',
-        		'DestUniqueID' => 'DestUniqueID',
-            ),
-            'ExtensionStatus' => array(
-                'Privilege' => 'Privilege',
-                'Status' => 'Status',
-                'Exten' => 'Extension',
-                'Hint' => 'Hint',
-        		'Context' => 'Context',
-            ),
-            'Hangup' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Cause' => 'Cause',
-                'cause-txt' => 'cause-txt'
-            ),
-            'Hold' => array(
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Status' => 'Status',
-                'Channel' => 'Channel',
-            ),
-        	'Join' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-        		'UniqueID' => 'UniqueID',
-                'Position' => 'Position',
-                'Queue' => 'Queue',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'Count' => 'Count',
-            ),
-            'Leave' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Count' => 'Count',
-                'Queue' => 'Queue'
-            ),
-        	'ListDialplan' => array(
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'Registrar' => 'Registrar',
-                'IncludeContext' => 'IncludeContext'
-            ),
-            'Masquerade' => array(
-                'OriginalState' => 'OriginalState',
-                'Original' => 'Original',
-                'CloneState' => 'CloneState',
-                'Clone' => 'Clone',
-                'Privilege' => 'Privilege',
-            ),
-            'MessageWaiting' => array(
-        		'Privilege' => 'Privilege',
-        		'Waiting' => 'Waiting',
-        		'Mailbox' => 'Mailbox',
-            ),
-            'MusicOnHold' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-        		'State' => 'State',
-            ),
-            'NewAccountCode' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'AccountCode' => 'AccountCode',
-                'OldAccountCode' => 'OldAccountCode',
-            ),
-            'NewCallerid' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'CID-CallingPres' => 'CID-CallingPres'
-            ),
-            'Newchannel' => array(
-        		'UniqueID' => 'UniqueID',
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'AccountCode' => 'AccountCode',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-        	'Newexten' => array(
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-        		'UniqueID' => 'UniqueID',
-            ),
-        	'Newstate' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'UniqueID' => 'UniqueID',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName'
-            ),
-            'OriginateResponse' => array(
-                'CallerIdName' => 'CallerIdName',
-                'CallerIdNum' => 'CallerIdNum',
-                'Response' => 'Response',
-                'ActionID' => 'ActionID',
-                'UniqueID' => 'UniqueID',
-                'Reason' => 'Reason',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Exten' => 'Exten',
-                'Privilege' => 'Privilege'
-            ),
-            'PeerEntry' => array(
-                'RealtimeDevice' => 'RealtimeDevice',
-                'Status' => 'Status',
-                'ACL' => 'ACL',
-                'TextSupport' => 'TextSupport',
-                'VideoSupport' => 'VideoSupport',
-                'NatSupport' => 'NatSupport',
-                'Dynamic' => 'Dynamic',
-                'IPPort' => 'IPPort',
-                'IPAddress' => 'IPAddress',
-                'ChanObjectType' => 'ChanObjectType',
-                'ObjectName' => 'ObjectName',
-                'ChannelType' => 'ChannelType',
-            ),
-        	'PeerStatus' => array(
-                'Privilege' => 'Privilege',
-                'ChannelType' => 'ChannelType',
-                'Peer' => 'Peer',
-                'PeerStatus' => 'PeerStatus'
-            ),
-            'QueueMemberRemoved' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberPaused' => array(
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege',
-            	'Paused' => 1,
-            ),
-            'QueueMember' => array(
-                'Name' => 'Name',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-            ),
-            'QueueMemberAdded' => array(
-                'MemberName' => 'MemberName',
-                'LastCall' => 'LastCall',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-            	'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-            	'Membership' => 'Membership',
-                'Privilege' => 'Privilege'
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 1,
-                'Status' => 'Status',
-                'CallsTaken' => 'CallsTaken',
-                'Penalty' => 'Penalty',
-                'Membership' => 'Membership',
-                'MemberName' => 'MemberName',
-                'Location' => 'Location',
-                'Queue' => 'Queue',
-                'Privilege' => 'Privilege'
-            ),
-        	'QueueParams' => array(
-                'Completed' => '4',
-        		'HoldTime' => '5',
-                'Calls' => '6',
-                'Strategy' => 'Strategy',
-                'Max' => '6',
-                'Queue' => 'Queue',
-                'Weight' => '2',
-                'ServiceLevelPerf' => 'ServiceLevelPerf',
-                'ServiceLevel' => '1',
-                'Abandoned' => '3'
-            ),
-            'QueueSummaryComplete' => array(),
-        	'QueueSummary' => array(
-                'LongestHoldTime' => 'LongestHoldTime',
-                'HoldTime' => 'HoldTime',
-                'Callers' => 'Callers',
-                'Available' => 'Available',
-                'LoggedIn' => 'LoggedIn',
-                'Queue' => 'Queue',
-            ),
-            'QueueStatusComplete' => array(),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'PeerlistComplete' => array('ListItems' => 'ListItems'),
-            'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
-            'RTCPReceived' => array(
-                'DLSR' => 'DLSR',
-                'RTT' => 'RTT',
-                'LastSR' => 'LastSR',
-                'IAJitter' => 'IAJitter',
-                'SequenceNumberCycles' => 'SequenceNumberCycles',
-                'HighestSequence' => 'HighestSequence',
-                'PacketsLost' => 'PacketsLost',
-                'FractionLost' => 'FractionLost',
-                'SenderSSRC' => 'SenderSSRC',
-                'ReceptionReports' => 'ReceptionReports',
-                'PT' => 'PT',
-                'Privilege' => 'Privilege',
-                'From' => 'From',
-            ),
-            'RTCPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'RTCPSent' => array(
-                'DLSR' => 'DLSR',
-                'TheirLastSR' => 'TheirLastSR',
-                'IAJitter' => 'IAJitter',
-                'CumulativeLoss' => 'CumulativeLoss',
-                'FractionLost' => 'FractionLost',
-                'ReportBlock' => 'ReportBlock',
-                'SentOctets' => 'SentOctets',
-                'SentPackets' => 'SentPackets',
-                'SentRTP' => 'SentRTP',
-                'SentNTP' => 'SentNTP',
-                'OurSSRC' => 'OurSSRC',
-                'To' => 'To',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPSenderStat' => array(
-                'SRCount' => 'SRCount',
-                'RTT' => 'RTT',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'SentPackets' => 'SentPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege'
-            ),
-            'RTPReceiverStat' => array(
-                'RRCount' => 'RRCount',
-                'Jitter' => 'Jitter',
-                'LostPackets' => 'LostPackets',
-                'ReceivedPackets' => 'ReceivedPackets',
-                'SSRC' => 'SSRC',
-                'Privilege' => 'Privilege',
-                'Transit' => 'Transit'
-            ),
-            'Rename' => array(
-                'UniqueID' => 'UniqueID',
-                'Oldname' => 'Oldname',
-                'Newname' => 'Newname',
-                'Channel' => 'Channel',
-                'Privilege' => 'Privilege'
-            ),
-            'ShowDialPlanComplete' => array(
-                'listcontexts' => 'listcontexts',
-                'listpriorities' => 'listpriorities',
-                'listextensions' => 'listextensions',
-                'listitems' => 'listitems',
-                'privilege' => 'privilege'
-            ),
-            'Status' => array(
-                'BridgedUniqueID' => 'BridgedUniqueID',
-                'BridgedChannel' => 'BridgedChannel',
-                'Seconds' => 'Seconds',
-                'AccountCode' => 'AccountCode',
-                'Duration' => 'Duration',
-                'CallerIDNum' => 'CallerIDNum',
-                'ApplicationData' => 'ApplicationData',
-                'Application' => 'Application',
-                'ChannelStateDesc' => 'ChannelStateDesc',
-                'ChannelState' => 'ChannelState',
-                'Priority' => 'Priority',
-                'Extension' => 'Extension',
-                'Context' => 'Context',
-                'UniqueID' => 'UniqueID',
-        		'Privilege' => 'Privilege',
-                'Channel' => 'Channel'
-            ),
-            'Transfer' => array(
-                'TransferContext' => 'TransferContext',
-                'TransferExten' => 'TransferExten',
-                'TargetUniqueid' => 'TargetUniqueid',
-                'UniqueID' => 'UniqueID',
-                'SIP-Callid' => 'SIP-Callid',
-                'TargetChannel' => 'TargetChannel',
-                'Channel' => 'Channel',
-                'TransferType' => 'TransferType',
-                'TransferMethod' => 'TransferMethod',
-                'Privilege' => 'Privilege'
-            ),
-            'VoicemailUserEntryComplete' => array(),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VmContext',
-                'VoicemailBox' => 'VoicemailBox',
-                'Fullname' => 'Fullname',
-                'Email' => 'Email',
-                'Pager' => 'Pager',
-                'ServerEmail' => 'ServerEmail',
-                'MailCommand' => 'MailCommand',
-                'Language' => 'Language',
-                'Timezone' => 'Timezone',
-                'Callback' => 'Callback',
-                'DialOut' => 'DialOut',
-                'UniqueID' => 'UniqueID',
-                'ExitContext' => 'ExitContext',
-                'SayDurationMin' => 'SayDurationMin',
-                'SayEnvelope' => 'SayEnvelope',
-                'SayCID' => 'SayCID',
-                'AttachMessage' => 'AttachMessage',
-                'AttachmentFormat' => 'AttachmentFormat',
-                'DeleteMessage' => 'DeleteMessage',
-                'VolumeGain' => 'VolumeGain',
-                'CanReview' => 'CanReview',
-                'CallOperator' => 'CallOperator',
-                'MaxMessageCount' => 'MaxMessageCount',
-                'MaxMessageLength' => 'MaxMessageLength',
-                'NewMessageCount' => 'NewMessageCount'
-            ),
-            'DBGetResponse' => array(
-                'Family' => 'Family',
-                'Key' => 'Key',
-                'Val' => 'Val'
-            ),
-        	'ParkedCallsComplete' => array(),
-        	'StatusComplete' => array('Items' => 'Items'),
-            'RegistrationsComplete' => array('ListItems' => 'ListItems'),
-            'DTMF' => array(
-            	'Privilege' => 'Privilege',
-        		'UniqueID' => 'UniqueID',
-                'Channel' => 'Channel',
-                'Direction' => 'Direction',
-                'End' => 'End',
-                'Begin' => 'Begin',
-                'Digit' => 'Digit'
-        	),
-            'AGIExec' => array(
-            	'Privilege' => 'Privilege',
-            	'CommandId' => 'CommandId',
-                'SubEvent' => 'SubEvent',
-                'Channel' => 'Channel',
-                'Command' => 'Command',
-                'Result' => 'Result',
-                'ResultCode' => 'ResultCode'
-        	),
-            'VarSet' => array(
-            	'Privilege' => 'Privilege',
-                'Channel' => 'Channel',
-                'Variable' => 'Variable',
-                'Value' => 'Value',
-        	    'UniqueID' => 'UniqueID'
-        	),
-        	'Unlink' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	),
-        	'Bridge' => array(
-        		'Privilege' => 'Privilege',
-        	    'CallerID1' => 'CallerID1',
-        	    'CallerID2' => 'CallerID2',
-        	    'UniqueID1' => 'UniqueID1',
-        		'UniqueID2' => 'UniqueID2',
-        	    'Channel1' => 'Channel1',
-        		'Channel2' => 'Channel2',
-        	    'BridgeState' => 'BridgeStart',
-        	    'BridgeType' => 'BridgeType'
-        	),
-        	'vgsm_sms_rx' => array(
-        		'Privilege' => 'Privilege',
-        		'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
-        	    'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
-        	    'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
-        	    'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
-        	    'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
-        	    'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
-        	    'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
-        	    'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
-        	    'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
-        	    'X-SMS-Message-Type' => 'X-SMS-Message-Type',
-        	    'Content' => 'Content',
-        	    'Date' => 'Date',
-        	    'Content-Transfer-Encoding' => 'ContentEncoding',
-        		'Content-Type' => 'ContentType',
-        	    'MIME-Version' => 'MIME-Version',
-        	    'Subject' => 'Subject',
-        	    'From' => 'From',
-        	    'Received' => 'Received'
-        	),
-        	'vgsm_net_state' => array(
-        		'Privilege' => 'Privilege',
-        		'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
-        	),
-        	'vgsm_me_state' => array(
-        		'Privilege' => 'Privilege',
-        	    'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
-        	    'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
-        	    'X-vGSM-ME-State' => 'X-vGSM-ME-State',
-            ),
-            'CEL' => array(
-                'AMAFlags' => 'AMAFlags',
-                'AccountCode' => 'AccountCode',
-                'AppData' => 'AppData',
-                'Application' => 'Application',
-                'CallerIDani' => 'CallerIDani',
-                'CallerIDdnid' => 'CallerIDdnid',
-                'CallerIDname' => 'CallerIDname',
-                'CallerIDnum' => 'CallerIDnum',
-                'CallerIDrdnis' => 'CallerIDrdnis',
-                'Channel' => 'Channel',
-                'Context' => 'Context',
-                'Event' => 'Event',
-                'EventName' => 'EventName',
-                'EventTime' => 'EventTime',
-                'Exten' => 'Exten',
-                'Extra' => 'Extra',
-                'LinkedID' => 'LinkedID',
-                'Peer' => 'Peer',
-                'PeerAccount' => 'PeerAccount',
-                'Privilege' => 'Privilege',
-                'Timestamp' => 'Timestamp',
-                'UniqueID' => 'UniqueID',
-                'Userfield' => 'Userfield',
-            ),
-            'ParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'Timeout' => 'Timeout',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'UnParkedCall' => array(
-                'Privilege' => 'Privilege',
-                'Parkinglot' => 'Parkinglot',
-                'From' => 'From',
-                'ConnectedLineNum' => 'ConnectedLineNum',
-                'ConnectedLineName' => 'ConnectedLineName',
-                'Channel' => 'Channel',
-                'CallerIDNum' => 'CallerIDNum',
-                'CallerIDName' => 'CallerIDName',
-                'UniqueID' => 'UniqueID',
-                'Exten' => 'Exten'
-            ),
-            'Link' => array(
-                'Privilege' => 'Privilege',
-                'CallerID1' => 'CallerID1',
-                'CallerID2' => 'CallerID2',
-                'UniqueID1' => 'UniqueID1',
-                'UniqueID2' => 'UniqueID2',
-                'Channel1' => 'Channel1',
-                'Channel2' => 'Channel2'
-            ),
-        );
-        $eventGetters = array(
-            'UserEvent' => array(
-                'UserEvent' => 'UserEventName'
-            ),
-            'AsyncAGI' => array(
-                'Env' => 'Environment'
-            ),
-            'Agents' => array(
-                'LoggedInChan' => 'Channel'
-            ),
-        	'ExtensionStatus' => array(
-                'Exten' => 'Extension'
-            ),
-            'Hangup' => array(
-                'cause-txt' => 'CauseText'
-             ),
-        	'ListDialplan' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'NewCallerid' => array(
-                'CID-CallingPres' => 'CallerIdPres'
-            ),
-            'Newchannel' => array('Exten' => 'Extension'),
-        	'Newexten' => array(
-                'AppData' => 'ApplicationData',
-            ),
-            'QueueMemberStatus' => array(
-                'Paused' => 'Pause'
-            ),
-            'QueueMember' => array(
-                'Name' => 'MemberName'
-            ),
-        	'AGIExec' => array(),
-            'Transfer' => array(
-                'SIP-Callid' => 'SipCallID',
-            ),
-            'VoicemailUserEntry' => array(
-                'VmContext' => 'VoicemailContext',
-            ),
-            'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
-            'VarSet' => array('Variable' => 'VariableName'),
-        	'StatusComplete' => array('Items' => 'ListItems'),
-            'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
-        	'vgsm_sms_rx' => array(
-        	    'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
-        	    'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
-        	    'X-SMS-Reply-Path' => 'ReplyPath',
-        	    'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
-                'X-SMS-SMCC-Number' => 'SMCCNumber',
-        	    'X-SMS-SMCC-TON' => 'SMCCTON',
-        	    'X-SMS-SMCC-NP' => 'SMCCNP',
-        	    'X-SMS-Sender-Number' => 'SenderNumber',
-        	    'X-SMS-Sender-TON' => 'SenderTON',
-        	    'X-SMS-Sender-NP' => 'SenderNP',
-        	    'X-SMS-Message-Type' => 'MessageType',
-                'Content-Transfer-Encoding' => 'ContentEncoding',
-                'Content-Type' => 'ContentType',
-                'MIME-Version' => 'MIMEVersion'
-        	),
-        	'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
-        	'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
-        	'vgsm_me_state' => array(
-        		'X-vGSM-ME-State-Change-Reason' => 'Reason',
-        	    'X-vGSM-ME-Old-State' => 'OldState',
-        	    'X-vGSM-ME-State' => 'State',
-        	),
-            'ParkedCall' => array('Exten' => 'Extension'),
-            'UnParkedCall' => array('Exten' => 'Extension')
-        );
-        foreach ($eventNames as $eventName) {
-            $this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
-        }
-    }
+	public function setUp()
+	{
+		$this->_properties = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+		);
+	}
+	/**
+	 * @test
+	 */
+	public function can_report_events()
+	{
+		$eventValues = array(
+			'UserEvent' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'UserEvent' => 'UserEvent'
+			),
+			'Registry' => array(
+				'Channel' => 'Channel',
+				'Domain' => 'Domain',
+				'Status' => 'Status'
+			),
+			'JabberEvent' => array(
+				'Privilege' => 'Privilege',
+				'Account' => 'Account',
+				'Packet' => 'Packet'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Env',
+				'Channel' => 'Channel',
+				'CommandId' => 'CommandId',
+				'Privilege' => 'Privilege',
+				'SubEvent' => 'SubEvent',
+				'Result' => 'Result'
+			),
+			'FullyBooted' => array(),
+			'DongleUSSDStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			 ),
+			'DongleNewUSSDBase64' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewCUSD' => array(
+				'Device' => 'Device',
+				'Message' => 'Message',
+				'Privilege' => 'Privilege'
+			),
+			'DongleNewUSSD' => array(
+				'Device' => 'Device',
+				'LineCount' => 'LineCount',
+				'Privilege' => 'Privilege'
+			),
+			'DongleDeviceEntry' => array(
+				'Device' => 'Device',
+				'AudioSetting' => 'AudioSetting',
+				'DataSetting' => 'DataSetting',
+				'IMEISetting' => 'IMEISetting',
+				'IMSISetting' => 'IMSISetting',
+				'ChannelLanguage' => 'ChannelLanguage',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Group' => 'Group',
+				'RXGain' => 'RXGain',
+				'TXGain' => 'TXGain',
+				'U2DIAG' => 'U2DIAG',
+				'UseCallingPres' => 'UseCallingPres',
+				'DefaultCallingPres' => 'DefaultCallingPres',
+				'AutoDeleteSMS' => 'AutoDeleteSMS',
+				'DisableSMS' => 'DisableSMS',
+				'ResetDongle' => 'ResetDongle',
+				'SMSPDU' => 'SMSPDU',
+				'CallWaitingSetting' => 'CallWaitingSetting',
+				'DTMF' => 'DTMF',
+				'MinimalDTMFGap' => 'MinimalDTMFGap',
+				'MinimalDTMFDuration' => 'MinimalDTMFDuration',
+				'MinimalDTMFInterval' => 'MinimalDTMFInterval',
+				'State' => 'State',
+				'AudioState' => 'AudioState',
+				'DataState' => 'DataState',
+				'Voice' => 'Voice',
+				'SMS' => 'SMS',
+				'Manufacturer' => 'Manufacturer',
+				'Model' => 'Model',
+				'Firmware' => 'Firmware',
+				'IMEIState' => 'IMEIState',
+				'IMSIState' => 'IMSIState',
+				'GSMRegistrationStatus' => 'GSMRegistrationStatus',
+				'RSSI' => 'RSSI',
+				'Mode' => 'Mode',
+				'Submode' => 'Submode',
+				'ProviderName' => 'ProviderName',
+				'LocationAreaCode' => 'LocationAreaCode',
+				'CellID' => 'CellID',
+				'SubscriberNumber' => 'SubscriberNumber',
+				'SMSServiceCenter' => 'SMSServiceCenter',
+				'UseUCS2Encoding' => 'UseUCS2Encoding',
+				'USSDUse7BitEncoding' => 'USSDUse7BitEncoding',
+				'USSDUseUCS2Decoding' => 'USSDUseUCS2Decoding',
+				'TasksInQueue' => 'TasksInQueue',
+				'CommandsInQueue' => 'CommandsInQueue',
+				'CallWaitingState' => 'CallWaitingState',
+				'CurrentDeviceState' => 'CurrentDeviceState',
+				'DesiredDeviceState' => 'DesiredDeviceState',
+				'CallsChannels' => 'CallsChannels',
+				'Active' => 'Active',
+				'Held' => 'Held',
+				'Dialing' => 'Dialing',
+				'Alerting' => 'Alerting',
+				'Incoming' => 'Incoming',
+				'Waiting' => 'Waiting',
+				'Releasing' => 'Releasing',
+				'Initializing' => 'Initializing'
+			),
+			'DongleShowDevicesComplete' => array('ListItems' => 'items'),
+			'DongleSMSStatus' => array(
+				'Privilege' => 'Privilege',
+				'Id' => 'Id',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'DongleStatus' => array(
+				'Privilege' => 'Privilege',
+				'Device' => 'Device',
+				'Status' => 'Status'
+			),
+			'AgentConnect' => array(
+				'HoldTime' => 'HoldTime',
+				'Privilege' => 'Privilege',
+				'BridgedChannel' => 'BridgedChannel',
+				'RingTime' => 'RingTime',
+				'Member' => 'Member',
+				'MemberName' => 'MemberName',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Queue' => 'Queue'
+			),
+			'Agentlogoff' => array(
+				'Logintime' => 'Logintime',
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+			),
+			'Agentlogin' => array(
+				'UniqueID' => 'UniqueID',
+				'Agent' => 'Agent',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+			),
+			'AgentsComplete' => array(),
+			'Agents' => array(
+				'TalkingToChannel' => 'TalkingToChannel',
+				'TalkingTo' => 'TalkingTo',
+				'LoggedInTime' => 'LoggedInTime',
+				'LoggedInChan' => 'LoggedInChan',
+				'Name' => 'Name',
+				'Status' => 'Status',
+				'Agent' => 'Agent'
+			),
+			'ChannelUpdate' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'ChannelType' => 'ChannelType',
+				'UniqueID' => 'UniqueID',
+				'SIPfullcontact' => 'SIPfullcontact',
+				'SIPcallid' => 'SIPcallid'
+			),
+			'CoreShowChannel' => array(
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'AccountCode' => 'AccountCode',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'CallerIDNum' => 'CallerIDNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Duration' => 'Duration',
+			),
+			'DAHDIShowChannels' => array(
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Alarm' => 'Alarm',
+				'DND' => 'DND',
+				'SignallingCode' => 'SignallingCode',
+				'Signalling' => 'Signalling'
+			),
+			'Dial' => array(
+				'Privilege' => 'Privilege',
+				'Destination' => 'Destination',
+				'SubEvent' => 'SubEvent',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'DialStatus' => 'DialStatus',
+				'DialString' => 'DialString',
+				'UniqueID' => 'UniqueID',
+				'DestUniqueID' => 'DestUniqueID',
+			),
+			'ExtensionStatus' => array(
+				'Privilege' => 'Privilege',
+				'Status' => 'Status',
+				'Exten' => 'Extension',
+				'Hint' => 'Hint',
+				'Context' => 'Context',
+			),
+			'Hangup' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Cause' => 'Cause',
+				'cause-txt' => 'cause-txt'
+			),
+			'Hold' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Status' => 'Status',
+				'Channel' => 'Channel',
+			),
+			'Join' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'Position' => 'Position',
+				'Queue' => 'Queue',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'Count' => 'Count',
+			),
+			'Leave' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Count' => 'Count',
+				'Queue' => 'Queue'
+			),
+			'ListDialplan' => array(
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'Registrar' => 'Registrar',
+				'IncludeContext' => 'IncludeContext'
+			),
+			'Masquerade' => array(
+				'OriginalState' => 'OriginalState',
+				'Original' => 'Original',
+				'CloneState' => 'CloneState',
+				'Clone' => 'Clone',
+				'Privilege' => 'Privilege',
+			),
+			'MessageWaiting' => array(
+				'Privilege' => 'Privilege',
+				'Waiting' => 'Waiting',
+				'Mailbox' => 'Mailbox',
+			),
+			'MusicOnHold' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'State' => 'State',
+			),
+			'NewAccountCode' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'AccountCode' => 'AccountCode',
+				'OldAccountCode' => 'OldAccountCode',
+			),
+			'NewCallerid' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'CID-CallingPres' => 'CID-CallingPres'
+			),
+			'Newchannel' => array(
+				'UniqueID' => 'UniqueID',
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'AccountCode' => 'AccountCode',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'Newexten' => array(
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+			),
+			'Newstate' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'UniqueID' => 'UniqueID',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName'
+			),
+			'OriginateResponse' => array(
+				'CallerIdName' => 'CallerIdName',
+				'CallerIdNum' => 'CallerIdNum',
+				'Response' => 'Response',
+				'ActionID' => 'ActionID',
+				'UniqueID' => 'UniqueID',
+				'Reason' => 'Reason',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Exten' => 'Exten',
+				'Privilege' => 'Privilege'
+			),
+			'PeerEntry' => array(
+				'RealtimeDevice' => 'RealtimeDevice',
+				'Status' => 'Status',
+				'ACL' => 'ACL',
+				'TextSupport' => 'TextSupport',
+				'VideoSupport' => 'VideoSupport',
+				'NatSupport' => 'NatSupport',
+				'Dynamic' => 'Dynamic',
+				'IPPort' => 'IPPort',
+				'IPAddress' => 'IPAddress',
+				'ChanObjectType' => 'ChanObjectType',
+				'ObjectName' => 'ObjectName',
+				'ChannelType' => 'ChannelType',
+			),
+			'PeerStatus' => array(
+				'Privilege' => 'Privilege',
+				'ChannelType' => 'ChannelType',
+				'Peer' => 'Peer',
+				'PeerStatus' => 'PeerStatus'
+			),
+			'QueueMemberRemoved' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberPaused' => array(
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege',
+				'Paused' => 1,
+			),
+			'QueueMember' => array(
+				'Name' => 'Name',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+			),
+			'QueueMemberAdded' => array(
+				'MemberName' => 'MemberName',
+				'LastCall' => 'LastCall',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'Privilege' => 'Privilege'
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 1,
+				'Status' => 'Status',
+				'CallsTaken' => 'CallsTaken',
+				'Penalty' => 'Penalty',
+				'Membership' => 'Membership',
+				'MemberName' => 'MemberName',
+				'Location' => 'Location',
+				'Queue' => 'Queue',
+				'Privilege' => 'Privilege'
+			),
+			'QueueParams' => array(
+				'Completed' => '4',
+				'HoldTime' => '5',
+				'Calls' => '6',
+				'Strategy' => 'Strategy',
+				'Max' => '6',
+				'Queue' => 'Queue',
+				'Weight' => '2',
+				'ServiceLevelPerf' => 'ServiceLevelPerf',
+				'ServiceLevel' => '1',
+				'Abandoned' => '3'
+			),
+			'QueueSummaryComplete' => array(),
+			'QueueSummary' => array(
+				'LongestHoldTime' => 'LongestHoldTime',
+				'HoldTime' => 'HoldTime',
+				'Callers' => 'Callers',
+				'Available' => 'Available',
+				'LoggedIn' => 'LoggedIn',
+				'Queue' => 'Queue',
+			),
+			'QueueStatusComplete' => array(),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'PeerlistComplete' => array('ListItems' => 'ListItems'),
+			'CoreShowChannelsComplete' => array('ListItems' => 'ListItems'),
+			'RTCPReceived' => array(
+				'DLSR' => 'DLSR',
+				'RTT' => 'RTT',
+				'LastSR' => 'LastSR',
+				'IAJitter' => 'IAJitter',
+				'SequenceNumberCycles' => 'SequenceNumberCycles',
+				'HighestSequence' => 'HighestSequence',
+				'PacketsLost' => 'PacketsLost',
+				'FractionLost' => 'FractionLost',
+				'SenderSSRC' => 'SenderSSRC',
+				'ReceptionReports' => 'ReceptionReports',
+				'PT' => 'PT',
+				'Privilege' => 'Privilege',
+				'From' => 'From',
+			),
+			'RTCPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'RTCPSent' => array(
+				'DLSR' => 'DLSR',
+				'TheirLastSR' => 'TheirLastSR',
+				'IAJitter' => 'IAJitter',
+				'CumulativeLoss' => 'CumulativeLoss',
+				'FractionLost' => 'FractionLost',
+				'ReportBlock' => 'ReportBlock',
+				'SentOctets' => 'SentOctets',
+				'SentPackets' => 'SentPackets',
+				'SentRTP' => 'SentRTP',
+				'SentNTP' => 'SentNTP',
+				'OurSSRC' => 'OurSSRC',
+				'To' => 'To',
+				'Privilege' => 'Privilege'
+			),
+			'RTPSenderStat' => array(
+				'SRCount' => 'SRCount',
+				'RTT' => 'RTT',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'SentPackets' => 'SentPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege'
+			),
+			'RTPReceiverStat' => array(
+				'RRCount' => 'RRCount',
+				'Jitter' => 'Jitter',
+				'LostPackets' => 'LostPackets',
+				'ReceivedPackets' => 'ReceivedPackets',
+				'SSRC' => 'SSRC',
+				'Privilege' => 'Privilege',
+				'Transit' => 'Transit'
+			),
+			'Rename' => array(
+				'UniqueID' => 'UniqueID',
+				'Oldname' => 'Oldname',
+				'Newname' => 'Newname',
+				'Channel' => 'Channel',
+				'Privilege' => 'Privilege'
+			),
+			'ShowDialPlanComplete' => array(
+				'listcontexts' => 'listcontexts',
+				'listpriorities' => 'listpriorities',
+				'listextensions' => 'listextensions',
+				'listitems' => 'listitems',
+				'privilege' => 'privilege'
+			),
+			'Status' => array(
+				'BridgedUniqueID' => 'BridgedUniqueID',
+				'BridgedChannel' => 'BridgedChannel',
+				'Seconds' => 'Seconds',
+				'AccountCode' => 'AccountCode',
+				'Duration' => 'Duration',
+				'CallerIDNum' => 'CallerIDNum',
+				'ApplicationData' => 'ApplicationData',
+				'Application' => 'Application',
+				'ChannelStateDesc' => 'ChannelStateDesc',
+				'ChannelState' => 'ChannelState',
+				'Priority' => 'Priority',
+				'Extension' => 'Extension',
+				'Context' => 'Context',
+				'UniqueID' => 'UniqueID',
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel'
+			),
+			'Transfer' => array(
+				'TransferContext' => 'TransferContext',
+				'TransferExten' => 'TransferExten',
+				'TargetUniqueid' => 'TargetUniqueid',
+				'UniqueID' => 'UniqueID',
+				'SIP-Callid' => 'SIP-Callid',
+				'TargetChannel' => 'TargetChannel',
+				'Channel' => 'Channel',
+				'TransferType' => 'TransferType',
+				'TransferMethod' => 'TransferMethod',
+				'Privilege' => 'Privilege'
+			),
+			'VoicemailUserEntryComplete' => array(),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VmContext',
+				'VoicemailBox' => 'VoicemailBox',
+				'Fullname' => 'Fullname',
+				'Email' => 'Email',
+				'Pager' => 'Pager',
+				'ServerEmail' => 'ServerEmail',
+				'MailCommand' => 'MailCommand',
+				'Language' => 'Language',
+				'Timezone' => 'Timezone',
+				'Callback' => 'Callback',
+				'DialOut' => 'DialOut',
+				'UniqueID' => 'UniqueID',
+				'ExitContext' => 'ExitContext',
+				'SayDurationMin' => 'SayDurationMin',
+				'SayEnvelope' => 'SayEnvelope',
+				'SayCID' => 'SayCID',
+				'AttachMessage' => 'AttachMessage',
+				'AttachmentFormat' => 'AttachmentFormat',
+				'DeleteMessage' => 'DeleteMessage',
+				'VolumeGain' => 'VolumeGain',
+				'CanReview' => 'CanReview',
+				'CallOperator' => 'CallOperator',
+				'MaxMessageCount' => 'MaxMessageCount',
+				'MaxMessageLength' => 'MaxMessageLength',
+				'NewMessageCount' => 'NewMessageCount'
+			),
+			'DBGetResponse' => array(
+				'Family' => 'Family',
+				'Key' => 'Key',
+				'Val' => 'Val'
+			),
+			'ParkedCallsComplete' => array(),
+			'StatusComplete' => array('Items' => 'Items'),
+			'RegistrationsComplete' => array('ListItems' => 'ListItems'),
+			'DTMF' => array(
+				'Privilege' => 'Privilege',
+				'UniqueID' => 'UniqueID',
+				'Channel' => 'Channel',
+				'Direction' => 'Direction',
+				'End' => 'End',
+				'Begin' => 'Begin',
+				'Digit' => 'Digit'
+			),
+			'AGIExec' => array(
+				'Privilege' => 'Privilege',
+				'CommandId' => 'CommandId',
+				'SubEvent' => 'SubEvent',
+				'Channel' => 'Channel',
+				'Command' => 'Command',
+				'Result' => 'Result',
+				'ResultCode' => 'ResultCode'
+			),
+			'VarSet' => array(
+				'Privilege' => 'Privilege',
+				'Channel' => 'Channel',
+				'Variable' => 'Variable',
+				'Value' => 'Value',
+				'UniqueID' => 'UniqueID'
+			),
+			'Unlink' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+			),
+			'Bridge' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2',
+				'BridgeState' => 'BridgeStart',
+				'BridgeType' => 'BridgeType'
+			),
+			'vgsm_sms_rx' => array(
+				'Privilege' => 'Privilege',
+				'X-SMS-Status-Report-Indication' => 'X-SMS-Status-Report-Indication',
+				'X-SMS-User-Data-Header-Indicator' => 'X-SMS-User-Data-Header-Indicator',
+				'X-SMS-Reply-Path' => 'X-SMS-Reply-Path',
+				'X-SMS-More-Messages-To-Send' => 'X-SMS-More-Messages-To-Send',
+				'X-SMS-SMCC-Number' => 'X-SMS-SMCC-Number',
+				'X-SMS-SMCC-TON' => 'X-SMS-SMCC-TON',
+				'X-SMS-SMCC-NP' => 'X-SMS-SMCC-NP',
+				'X-SMS-Sender-Number' => 'X-SMS-Sender-Number',
+				'X-SMS-Sender-TON' => 'X-SMS-Sender-TON',
+				'X-SMS-Sender-NP' => 'X-SMS-Sender-NP',
+				'X-SMS-Message-Type' => 'X-SMS-Message-Type',
+				'Content' => 'Content',
+				'Date' => 'Date',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIME-Version',
+				'Subject' => 'Subject',
+				'From' => 'From',
+				'Received' => 'Received'
+			),
+			'vgsm_net_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-GSM-Registration' => 'X-vGSM-GSM-Registration',
+			),
+			'vgsm_me_state' => array(
+				'Privilege' => 'Privilege',
+				'X-vGSM-ME-State-Change-Reason' => 'X-vGSM-ME-State-Change-Reason',
+				'X-vGSM-ME-Old-State' => 'X-vGSM-ME-Old-State',
+				'X-vGSM-ME-State' => 'X-vGSM-ME-State',
+			),
+			'CEL' => array(
+				'AMAFlags' => 'AMAFlags',
+				'AccountCode' => 'AccountCode',
+				'AppData' => 'AppData',
+				'Application' => 'Application',
+				'CallerIDani' => 'CallerIDani',
+				'CallerIDdnid' => 'CallerIDdnid',
+				'CallerIDname' => 'CallerIDname',
+				'CallerIDnum' => 'CallerIDnum',
+				'CallerIDrdnis' => 'CallerIDrdnis',
+				'Channel' => 'Channel',
+				'Context' => 'Context',
+				'Event' => 'Event',
+				'EventName' => 'EventName',
+				'EventTime' => 'EventTime',
+				'Exten' => 'Exten',
+				'Extra' => 'Extra',
+				'LinkedID' => 'LinkedID',
+				'Peer' => 'Peer',
+				'PeerAccount' => 'PeerAccount',
+				'Privilege' => 'Privilege',
+				'Timestamp' => 'Timestamp',
+				'UniqueID' => 'UniqueID',
+				'Userfield' => 'Userfield',
+			),
+			'ParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'Timeout' => 'Timeout',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'UnParkedCall' => array(
+				'Privilege' => 'Privilege',
+				'Parkinglot' => 'Parkinglot',
+				'From' => 'From',
+				'ConnectedLineNum' => 'ConnectedLineNum',
+				'ConnectedLineName' => 'ConnectedLineName',
+				'Channel' => 'Channel',
+				'CallerIDNum' => 'CallerIDNum',
+				'CallerIDName' => 'CallerIDName',
+				'UniqueID' => 'UniqueID',
+				'Exten' => 'Exten'
+			),
+			'Link' => array(
+				'Privilege' => 'Privilege',
+				'CallerID1' => 'CallerID1',
+				'CallerID2' => 'CallerID2',
+				'UniqueID1' => 'UniqueID1',
+				'UniqueID2' => 'UniqueID2',
+				'Channel1' => 'Channel1',
+				'Channel2' => 'Channel2'
+			),
+			'RequestBadFormat' => array(
+				'Privilege' => 'security,all',
+				'EventTV' => '2015-04-04T21:04:12.937+0200',
+				'Severity' => 'Informational',
+				'Service' => 'AMI',
+				'EventVersion' => '1',
+				'AccountID' => 'admin',
+				'SessionID' => '0x7fa9d41418c8',
+				'LocalAddress' => 'IPV4/TCP/127.0.0.1/5038',
+				'RemoteAddress' => 'IPV4/TCP/127.0.0.1/48658',
+				'UsingPassword' => '0',
+				'SessionTV' => '2015-04-04T21:04:12.937+0200',
+			),
+		);
+		$eventTranslatedValues = array(
+			'QueueMemberStatus' => array(
+				'Paused' => true
+			),
+			'QueueMemberPaused' => array(
+				'Paused' => true
+			),
+			'QueueMember' => array(
+				'Paused' => true
+			),
+			'QueueMemberAdded' => array(
+				'Paused' => true
+			),
+			'RequestBadFormat' => array(
+				'EventVersion' => 1,
+				'UsingPassword' => false,
+			),
+		);
+		$eventGetters = array(
+			'UserEvent' => array(
+				'UserEvent' => 'UserEventName'
+			),
+			'AsyncAGI' => array(
+				'Env' => 'Environment'
+			),
+			'Agents' => array(
+				'LoggedInChan' => 'Channel'
+			),
+			'ExtensionStatus' => array(
+				'Exten' => 'Extension'
+			),
+			'Hangup' => array(
+				'cause-txt' => 'CauseText'
+			 ),
+			'ListDialplan' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'NewCallerid' => array(
+				'CID-CallingPres' => 'CallerIdPres'
+			),
+			'Newchannel' => array('Exten' => 'Extension'),
+			'Newexten' => array(
+				'AppData' => 'ApplicationData',
+			),
+			'QueueMemberStatus' => array(
+				'Paused' => 'Pause'
+			),
+			'QueueMember' => array(
+				'Name' => 'MemberName'
+			),
+			'AGIExec' => array(),
+			'Transfer' => array(
+				'SIP-Callid' => 'SipCallID',
+			),
+			'VoicemailUserEntry' => array(
+				'VmContext' => 'VoicemailContext',
+			),
+			'PeerEntry' => array('ChanObjectType' => 'ChannelObjectType'),
+			'VarSet' => array('Variable' => 'VariableName'),
+			'StatusComplete' => array('Items' => 'ListItems'),
+			'DBGetResponse' => array('Key' => 'KeyName', 'Val' => 'Value'),
+			'vgsm_sms_rx' => array(
+				'X-SMS-Status-Report-Indication' => 'StatusReportIndication',
+				'X-SMS-User-Data-Header-Indicator' => 'DataHeaderIndicator',
+				'X-SMS-Reply-Path' => 'ReplyPath',
+				'X-SMS-More-Messages-To-Send' => 'MoreMessagesToSend',
+				'X-SMS-SMCC-Number' => 'SMCCNumber',
+				'X-SMS-SMCC-TON' => 'SMCCTON',
+				'X-SMS-SMCC-NP' => 'SMCCNP',
+				'X-SMS-Sender-Number' => 'SenderNumber',
+				'X-SMS-Sender-TON' => 'SenderTON',
+				'X-SMS-Sender-NP' => 'SenderNP',
+				'X-SMS-Message-Type' => 'MessageType',
+				'Content-Transfer-Encoding' => 'ContentEncoding',
+				'Content-Type' => 'ContentType',
+				'MIME-Version' => 'MIMEVersion'
+			),
+			'DAHDIShowChannelsComplete' => array('items' => 'ListItems'),
+			'vgsm_net_state' => array('X-vGSM-GSM-Registration' => 'State'),
+			'vgsm_me_state' => array(
+				'X-vGSM-ME-State-Change-Reason' => 'Reason',
+				'X-vGSM-ME-Old-State' => 'OldState',
+				'X-vGSM-ME-State' => 'State',
+			),
+			'ParkedCall' => array('Exten' => 'Extension'),
+			'UnParkedCall' => array('Exten' => 'Extension')
+		);
+		foreach (array_keys($eventValues) as $eventName) {
+			$this->_testEvent($eventName, $eventGetters, $eventValues[$eventName], $eventTranslatedValues);
+		}
+	}
 
-    private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
-    {
-        global $mock_stream_socket_client;
-        global $mock_stream_set_blocking;
-        global $mockTime;
-        global $standardAMIStart;
-        $eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
-        $mockTime = true;
-        $mock_stream_socket_client = true;
-        $mock_stream_set_blocking = true;
-        $options = array(
-            'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
-        	'host' => '2.3.4.5',
-            'scheme' => 'tcp://',
-        	'port' => 9999,
-        	'username' => 'asd',
-        	'secret' => 'asd',
-            'connect_timeout' => 10,
-        	'read_timeout' => 10
-        );
-        $write = array(
-        	"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
-        );
-        setFgetsMock($standardAMIStart, $write);
-        $client = new \PAMI\Client\Impl\ClientImpl($options);
-        $client->registerEventListener(new SomeListenerClass);
-	    $client->open();
-	    $message = array();
-	    $message[] = 'Event: ' . $eventName;
-	    foreach ($values as $key => $value) {
-	        $message[] = $key . ': ' . $value;
-	    }
-	    $message[] = '';
-	    setFgetsMock($message, $message);
-	    for($i = 0; $i < count($message); $i++) {
-	        $client->process();
-	    }
-	    $event = SomeListenerClass::$event;
-        $this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
-        foreach ($values as $key => $value) {
-            if (isset($getters[$eventName][$key])) {
-                $methodName = 'get' . $getters[$eventName][$key];
-            } else {
-                $methodName = 'get' . $key;
-            }
-            if (isset($translatedValues[$eventName][$key])) {
-                $value = $translatedValues[$eventName][$key];
-            }
-            $this->assertEquals($event->$methodName(), $value);
-        }
-    }
+	private function _testEvent($eventName, array $getters, array $values, array $translatedValues)
+	{
+		global $mock_stream_socket_client;
+		global $mock_stream_set_blocking;
+		global $mockTime;
+		global $standardAMIStart;
+		$eventClass = "\\PAMI\\Message\\Event\\" . $eventName . 'Event';
+		$mockTime = true;
+		$mock_stream_socket_client = true;
+		$mock_stream_set_blocking = true;
+		$options = array(
+			'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties',
+			'host' => '2.3.4.5',
+			'scheme' => 'tcp://',
+			'port' => 9999,
+			'username' => 'asd',
+			'secret' => 'asd',
+			'connect_timeout' => 10,
+			'read_timeout' => 10
+		);
+		$write = array(
+			"action: Login\r\nactionid: 1432.123\r\nusername: asd\r\nsecret: asd\r\n"
+		);
+		setFgetsMock($standardAMIStart, $write);
+		$client = new \PAMI\Client\Impl\ClientImpl($options);
+		$client->registerEventListener(new SomeListenerClass);
+		$client->open();
+		$message = array();
+		$message[] = 'Event: ' . $eventName;
+		foreach ($values as $key => $value) {
+			$message[] = $key . ': ' . $value;
+		}
+		$message[] = '';
+		setFgetsMock($message, $message);
+		for($i = 0; $i < count($message); $i++) {
+			$client->process();
+		}
+		$event = SomeListenerClass::$event;
+		$this->assertTrue($event instanceof $eventClass, "Class '" . get_class($event) . "' is not an instance of '$eventClass'");
+		foreach ($values as $key => $value) {
+			if (isset($getters[$eventName][$key])) {
+				$methodName = 'get' . $getters[$eventName][$key];
+			} else {
+				$methodName = 'get' . $key;
+			}
+			if (isset($translatedValues[$eventName][$key])) {
+				$value = $translatedValues[$eventName][$key];
+			}
+			$this->assertEquals($event->$methodName(), $value, "Event: '$eventName'->'$methodName' to retrieve Key: '$key', returned Value: '". var_dump($event->$methodName()) ."' instead of expected: '" . var_dump($value) . "'");
+		}
+	}
 }
 }

--- a/test/factories/Test_Factories.php
+++ b/test/factories/Test_Factories.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * This class will test the ami response factory
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage ReponseFactory
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+//namespace PAMI\Message\Response\Factory\Impl {
+namespace PAMI\Client\Impl {
+	/**
+	 * This class will test the response factory
+	 *
+	 * PHP Version 5
+	 *
+	 * @category   Pami
+	 * @package    Test
+	 * @subpackage Response Factory
+	 * @author     Diederik de Groot <ddegroot@users.sf.net>
+	 * @license    http://marcelog.github.com/ Apache License 2.0
+	 * @link       http://marcelog.github.com/
+	 */
+	class Test_ResponseFactory extends \PHPUnit_Framework_TestCase
+	{
+		private $_properties = array();
+
+		public function setUp()
+		{
+			$this->_properties = array(
+				'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+			);
+			if (isset($_properties['log4php.properties'])) {
+				\Logger::configure($_properties['log4php.properties']);
+			}
+			
+			$this->_logger = \Logger::getLogger('ResponseFactory');
+		}
+
+		/**
+		 * @test
+		 * 
+		 * we might want to revise this behaviour, ResponseMessage ie. GenericReponse should catch this and throw an exception
+		 */
+		public function can_create_genericresponse_with_empty_message()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('', false, false);
+			
+			// we might want to revise this behaviour, GenericReponse should capture this i think and throw
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_using_responsefactory()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, false);
+			$this->assertTrue ($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_responsehandler()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, 'Generic');
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$actionClass = "\\PAMI\\Message\\Action\\LoginAction";
+			$action = new $actionClass('test', 'boo');
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+			
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', $action, false);
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+	     * @expectedException PAMI\Exception\PAMIException
+		 */
+		public function can_get_exception_using_responsefactory_with_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\BooResponse";
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false, "boo");
+			$this->assertFalse($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+	}
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -15,6 +15,9 @@
     <testsuite name="Client">
       <directory suffix=".php">client</directory>
     </testsuite>
+    <testsuite name="Factories">
+      <directory suffix=".php">factories</directory>
+    </testsuite>
     <testsuite name="Autoloader">
       <directory suffix=".php">autoloader</directory>
     </testsuite>


### PR DESCRIPTION
Added ResponseFactory
 - Merged in origin/timeout branch to solve timeout issues (ed4f296 in seperate Pull Request)
 - Allows you to setResponseHandler("MyDefaultHandler") from MyMessageAction.php
 - Searches for Response with the same name as the Action /PAMI/Message/Action/TestAction -> /PAMI/Message/Response/TestResponse
 - Falls back to GenericResponse Handler (Like UnknownEvent) This will make it easier for people to extend the handling of ResponseMessage.php without having to change this file.
 - Added logging to both factory classes, so we can see what they produce. (Had to change the static function to a public function. Never being called with :: anyway .)

Added InputSanitizer

 - IncomingMessage Keys are pushed through sanitizer
 - Values are stored in the native type (integer / boolean / string / etc)
 - May have to be made optional (improvement / API backward compatibility)

Fixes:
    Sometime now() can be ahead of Message CreationTime, by the time we are asserting (slow machine)

Cleanup:
    Move eventTranslatedValues down