### PR TITLE
Fix Timeout Issue

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -408,7 +408,7 @@ class ClientImpl implements IClient
 	    while (1) {
 	    	stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
 			$this->process();
-			$info = @stream_get_meta_data($this->_socket);
+			$info = stream_get_meta_data($this->_socket);
 			if ($info['timed_out'] == false) {
 				$response = $this->getRelated($message);
 				if ($response != false) {

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -419,7 +419,7 @@ class ClientImpl implements IClient
 				break;
 			}
 		}
-		trow new ClientException("Read waittime: " . ($this->_rTimeout) . " exceeded (timeout).\n");
+		throw new ClientException("Read waittime: " . ($this->_rTimeout) . " exceeded (timeout).");
 	}
 
 	/**

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -406,11 +406,11 @@ class ClientImpl implements IClient
     	    throw new ClientException('Could not send message');
 	    }
 	    while (1) {
-	    	@stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
+	    	stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
 			$this->process();
 			$info = @stream_get_meta_data($this->_socket);
 			if ($info['timed_out'] == false) {
-				response = $this->getRelated($message);
+				$response = $this->getRelated($message);
 				if ($response != false) {
 					$this->_lastActionId = false;
 					return $response;

--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -405,20 +405,21 @@ class ClientImpl implements IClient
 	    if (@fwrite($this->_socket, $messageToSend) < $length) {
     	    throw new ClientException('Could not send message');
 	    }
-	    $read = 0;
-	    while($read <= $this->_rTimeout) {
-	        $this->process();
-	        $response = $this->getRelated($message);
-	        if ($response != false) {
-	            $this->_lastActionId = false;
-	            return $response;
-	        }
-	        usleep(1000); // 1ms delay
-	        if ($this->_rTimeout > 0) {
-	            $read++;
-	        }
-	    }
-	    throw new ClientException('Read timeout');
+	    while (1) {
+	    	@stream_set_timeout($this->_socket, $this->_rTimeout ? $this->_rTimeout : 1);
+			$this->process();
+			$info = @stream_get_meta_data($this->_socket);
+			if ($info['timed_out'] == false) {
+				response = $this->getRelated($message);
+				if ($response != false) {
+					$this->_lastActionId = false;
+					return $response;
+				}
+			} else {
+				break;
+			}
+		}
+		trow new ClientException("Read waittime: " . ($this->_rTimeout) . " exceeded (timeout).\n");
 	}
 
 	/**


### PR DESCRIPTION
Replace read retry with stream_set_timeout and stream_getmeta_data

Fixes the timeout issues i was heaving when asterisk is slow to respond

    loads of data being generated without flushing before returning a message::EOM).
    Data is trickling in but we timeout before EOM
    Adapted the mock tests to handle this.
    The repeated a->process() during tests should not be required any more
