### PR TITLE
Added Response Factory

### DIFF
--- a/src/mg/PAMI/Message/OutgoingMessage.php
+++ b/src/mg/PAMI/Message/OutgoingMessage.php
@@ -28,6 +28,8 @@
  */
 namespace PAMI\Message;
 
+use PAMI\Exception\PAMIException;
+
 /**
  * A generic outgoing message.
  *
@@ -41,4 +43,41 @@ namespace PAMI\Message;
  */
 abstract class OutgoingMessage extends Message
 {
+    /**
+     * String of the Class name to handle the Reponse to this Message
+     *
+     * @var string
+     */
+    private $_responseHandler;
+
+    /**
+     * Returns '_responseHandler'.
+     * @return string
+     */
+    public function getResponseHandler()
+    {
+        $res = "";
+        if (strlen($this->_responseHandler) > 0) {
+            $res = (string)$this->_responseHandler;
+        }
+        return $res;
+    }
+
+    /**
+     * Set '_responseHandler'.
+     *
+     * @return void
+     */
+    public function setResponseHandler($responseHandler)
+    {
+        if (0 == strlen($responseHandler)) {
+            throw new PAMIException('ResponseHandler cannot be empty.');
+        }
+        $className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+        if (class_exists($className, true)) {
+            $this->_responseHandler = $responseHandler;
+        } else {
+            throw new PAMIException('ResponseHandler could not be found.');
+        }
+    }
 }

--- a/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
+++ b/src/mg/PAMI/Message/Response/Factory/Impl/ResponseFactoryImpl.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This factory knows which response to return according to a given raw message
+ * from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2015 Diederik de Groot <ddegroot@users.sf.net>, Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response\Factory\Impl;
+
+use PAMI\Exception\PAMIException;
+use PAMI\Message\Response\ResponseMessage;
+use PAMI\Message\Response\GenericResponse;
+use PAMI\Message\Message;
+
+/**
+ * This factory knows which reponse handler to return according to a given raw message from ami,
+ * the outgoingMessageClass and responseHandler requested by the Action
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Response
+ * @subpackage Factory.Impl
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ResponseFactoryImpl
+{
+	private $_logger;
+	/**
+	 * This is our factory method.
+	 *
+	 * @param string $message Literal message as received from ami.
+	 * @param string $requestingAQction
+	 *
+	 * @return EventMessage
+	 */
+	public function createFromRaw($message, $requestingAction = false)
+	{
+		$responseclass = '\\PAMI\\Message\\Response\\GenericResponse';
+		$_className = false;
+
+		if ($requestingAction != false) {
+		    $responseHandler = $requestingAction->getResponseHandler();
+		    if ($responseHandler != "") {
+		        $_className = '\\PAMI\\Message\\Response\\' . $responseHandler . 'Response';
+		    } else {
+    			$_className = '\\PAMI\\Message\\Response\\' . substr(get_class($requestingAction), 20, -6) . 'Response';
+            }
+		}
+		if ($_className) {
+			if (class_exists($_className, true)) {
+				$responseclass = $_className;
+			} else if ($responseHandler != false){
+				throw new PAMIException('Response Class ' . $_className . '  requested via responseHandler, could not be found');
+			}
+		}
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('Created: ' . $responseclass . "\n");
+		return new $responseclass($message);
+	}
+
+	/**
+	 * Constructor. Nothing to see here, move along.
+	 *
+	 * @return void
+	 */
+    public function __construct($logger)
+    {
+        $this->_logger = $logger ? $logger : \Logger::getLogger(__CLASS__);
+		if ($this->_logger->isDebugEnabled()) $this->_logger->debug('------ Response Factory Created: ------ ' . "\n");
+    }
+}

--- a/src/mg/PAMI/Message/Response/GenericResponse.php
+++ b/src/mg/PAMI/Message/Response/GenericResponse.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Response;
+
+use PAMI\Message\Response\ResponseMessage;
+
+/**
+ * A generic response message from ami.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Response
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class GenericResponse extends ResponseMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawContent Literal message as received from ami.
+     *
+     * @return void
+     */
+    public function __construct($rawContent)
+    {
+        parent::__construct($rawContent);
+    }
+}

--- a/src/mg/PAMI/Message/Response/ResponseMessage.php
+++ b/src/mg/PAMI/Message/Response/ResponseMessage.php
@@ -32,6 +32,7 @@ namespace PAMI\Message\Response;
 use PAMI\Message\Message;
 use PAMI\Message\IncomingMessage;
 use PAMI\Message\Event\EventMessage;
+use PAMI\Exception\PAMIException;
 
 /**
  * A generic response message from ami.
@@ -45,19 +46,19 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ResponseMessage extends IncomingMessage
+abstract class ResponseMessage extends IncomingMessage
 {
     /**
      * Child events.
      * @var EventMessage[]
      */
-    private $_events;
+    protected $_events;
 
     /**
      * Is this response completed? (with all its events).
      * @var boolean
      */
-    private $_completed;
+    protected $_completed;
 
     /**
      * Serialize function.

--- a/test/factories/Test_Factories.php
+++ b/test/factories/Test_Factories.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This class will test the ami response factory
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Test
+ * @subpackage ReponseFactory
+ * @author     Diederik de Groot <ddegroot@users.sf.net>
+ * @license    http://marcelog.github.com/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+//namespace PAMI\Message\Response\Factory\Impl {
+namespace PAMI\Client\Impl {
+	/**
+	 * This class will test the response factory
+	 *
+	 * PHP Version 5
+	 *
+	 * @category   Pami
+	 * @package    Test
+	 * @subpackage Response Factory
+	 * @author     Diederik de Groot <ddegroot@users.sf.net>
+	 * @license    http://marcelog.github.com/ Apache License 2.0
+	 * @link       http://marcelog.github.com/
+	 */
+	class Test_ResponseFactory extends \PHPUnit_Framework_TestCase
+	{
+		private $_properties = array();
+
+		public function setUp()
+		{
+			$this->_properties = array(
+				'log4php.properties' => RESOURCES_DIR . DIRECTORY_SEPARATOR . 'log4php.properties'
+			);
+			if (isset($_properties['log4php.properties'])) {
+				\Logger::configure($_properties['log4php.properties']);
+			}
+			$this->_logger = \Logger::getLogger('ResponseFactory');
+		}
+
+		/**
+		 * @test
+		 * 
+		 * we might want to revise this behaviour, ResponseMessage ie. GenericReponse should catch this and throw an exception
+		 */
+		public function can_create_genericresponse_with_empty_message()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+
+			$response = $factory->createFromRaw('', false);
+
+			// we might want to revise this behaviour, GenericReponse should capture this i think and throw
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_using_responsefactory()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', false);
+			$this->assertTrue ($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$actionClass = "\\PAMI\\Message\\Action\\LoginAction";
+			$action = new $actionClass('test', 'boo');
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', $action);
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+    	/**
+		 * @test
+		 */
+		public function can_create_genericresponse_by_responsehandler()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$actionClass = "\\PAMI\\Message\\Action\\LoginAction";
+			$action = new $actionClass('test', 'boo');
+			$action->setResponseHandler('Generic');
+			$responseExpect = "PAMI\\Message\\Response\\GenericResponse";
+
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', $action);
+			$this->assertTrue($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+
+		/**
+		 * @test
+	     * @expectedException PAMI\Exception\PAMIException
+		 */
+		public function can_get_exception_using_responsefactory_with_outgoingMessageClass()
+		{
+			$factory = new \PAMI\Message\Response\Factory\Impl\ResponseFactoryImpl($this->_logger);
+			$actionClass = "\\PAMI\\Message\\Action\\LoginAction";
+			$action = new $actionClass('test', 'boo');
+			$action->setResponseHandler('DoesNotExit');
+			$responseExpect = "PAMI\\Message\\Response\\DoesNotExistResponse";
+
+			$response = $factory->createFromRaw('Response: Success\r\nMessage: Imaginary\r\n\r\n', $action);
+			$this->assertFalse($response instanceof $responseExpect, 'Expected Class: ' . $responseExpect .  ', But got class: ' . get_class($response));
+		}
+	}
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -18,6 +18,9 @@
     <testsuite name="Autoloader">
       <directory suffix=".php">autoloader</directory>
     </testsuite>
+    <testsuite name="Factories">
+      <directory suffix=".php">factories</directory>
+    </testsuite>
     <testsuite name="Actions">
       <directory suffix=".php">actions</directory>
     </testsuite>


### PR DESCRIPTION
Added ResponseFactory
- Allows you to setResponseHandler("MyDefaultHandler") from MyMessageAction.php
- Searches for Response with the same name as the Action /PAMI/Message/Action/TestAction -> /PAMI/Message/Response/TestResponse
- Falls back to GenericResponse Handler (Like UnknownEvent) This will make it easier for people to extend the handling of ResponseMessage.php without having to change this file.
  Added logging to this factory classes, so we can see what it produces.  Might be usefull in the Event Factory as well.
- Added initial test/factories/
- Kept the input key/value Sanitzer for a later PR
- Tried to preserve indentation as much as possible (looks ok as far as i can tell).
