### PR TITLE
More PHPdocs tweaks

### DIFF
--- a/src/mg/PAMI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAMI/Client/Impl/ClientImpl.php
@@ -197,7 +197,7 @@ class ClientImpl implements IClient
 	 * an optional predicate to invoke before calling the callback.
 	 *
 	 * @param mixed $listener
-	 * @param Closure|null $predicate
+	 * @param \Closure|null $predicate
 	 *
 	 * @return string
 	 */
@@ -225,7 +225,8 @@ class ClientImpl implements IClient
 	/**
 	 * Reads a complete message over the stream until EOM.
 	 *
-	 * @return string
+	 * @throws ClientException
+	 * @return \string[]
 	 */
 	protected function getMessages()
 	{
@@ -439,7 +440,6 @@ class ClientImpl implements IClient
 	 *
 	 * @param string[] $options Options for ami client.
 	 *
-	 * @return void
 	 */
 	public function __construct(array $options)
 	{


### PR DESCRIPTION
* Some IDE's may complain on [process() line#260](https://github.com/StrikeForceZero/PAMI/blob/1772e25fcf251b23aa1d8ccd20bb231982164728/src/mg/PAMI/Client/Impl/ClientImpl.php#L260) that the return of ```getMessages``` is a string when it is in fact a string array.

* might as well add the ```@throws ClientException``` for ```getMessages``` while we are in here as well.

* constructor doesn't exactly return a void, so we can remove that (PhpStorm likes to highlight everything...)

* ```Closure``` is a root namespace class


:)