### PR TITLE
Make Messages JsonSerializable

### DIFF
--- a/src/mg/PAMI/Message/Message.php
+++ b/src/mg/PAMI/Message/Message.php
@@ -39,7 +39,7 @@ namespace PAMI\Message;
  * @license  http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link     http://marcelog.github.com/PAMI/
  */
-abstract class Message
+abstract class Message implements \JsonSerializable
 {
 	/**
 	 * End Of Line means this token.
@@ -235,6 +235,16 @@ abstract class Message
     {
         return $this->getKey('ActionID');
     }
+
+	/**
+	 * Implements JsonSerializable
+	 *
+	 * @return object
+	 */
+	public function jsonSerialize ()
+	{
+		return ( object ) $this->keys;
+	}
 
 	/**
 	 * Constructor.

--- a/src/mg/PAMI/Message/Response/ResponseMessage.php
+++ b/src/mg/PAMI/Message/Response/ResponseMessage.php
@@ -45,7 +45,7 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ResponseMessage extends IncomingMessage
+class ResponseMessage extends IncomingMessage implements \JsonSerializable
 {
     /**
      * Child events.
@@ -159,6 +159,19 @@ class ResponseMessage extends IncomingMessage
     public function setActionId($actionId)
     {
         $this->setKey('ActionId', $actionId);
+    }
+
+    /**
+     * Implements JsonSerializable
+     *
+     * @return object
+     */
+    public function jsonSerialize ()
+    {
+        return ( object ) array_merge(array(
+            'completed' => $this->isComplete(),
+            'events' => $this->getEvents()
+        ), $this->keys);
     }
 
     /**


### PR DESCRIPTION
I'm not sure if this -the- best way but this allows restful apis serialize the response and event objects as json.

**Example for a laravel controller returning its QueueStatus route:**

```
public function QueueStatus(Request $request)
{
    return JsonResponse::create($this->client->send(new QueueStatusAction()));
}
```

**Response:**

```
{
  "completed": true,
  "events": [
    {
      "event": "QueueParams",
      "queue": "200",
      "max": "0",
      "strategy": "ringall",
      "calls": "0",
      "holdtime": "5",
      "talktime": "51",
      "completed": "2",
      "abandoned": "0",
      "servicelevel": "180",
      "servicelevelperf": "100.0",
      "weight": "1",
      "actionid": "1444144085.0061"
    },
    {
      "event": "QueueMember",
      "queue": "201",
      "name": "Some Person",
      "location": "Local/201@from-queue/n",
      "stateinterface": "hint:201@ext-local",
      "membership": "dynamic",
      "penalty": "0",
      "callstaken": "0",
      "lastcall": "0",
      "status": "5",
      "paused": "0",
      "actionid": "1444144085.0061"
    },
    {
      "event": "QueueStatusComplete",
      "actionid": "1444144085.0061"
    }
  ],
  "response": "Success",
  "actionid": "1444144085.0061",
  "message": "Queue status will follow"
}
```