### PR TITLE
Prevent fatal error on missing response

### DIFF
--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -284,8 +284,12 @@ class ClientImpl implements IClient
                 $bMsg = 'Event: ResponseEvent' . "\r\n";
                 $bMsg .= 'ActionId: ' . $this->lastActionId . "\r\n" . $aMsg;
                 $event = $this->messageToEvent($bMsg);
-                $response = $this->findResponse($event);
-                $response->addEvent($event);
+                $response = $this->findResponse($event);                
+                if ($response === false || $response->isComplete()) {
+                    $this->dispatch($event);
+                } else {
+                    $response->addEvent($event);
+                }
             }
             $this->logger->debug('----------------');
         }


### PR DESCRIPTION
findResponse sometimes returns "false" and this one branch in this function didn't check if response is false, so now I made it work the same way the other branch works. Not sure if isComplete should be used here...