### PR TITLE
Removed case-insensitive variables

### DIFF
--- a/src/PAMI/Message/Action/VGSMSMSTxAction.php
+++ b/src/PAMI/Message/Action/VGSMSMSTxAction.php
@@ -150,8 +150,8 @@ class VGSMSMSTxAction extends ActionMessage
     public function setConcatTotalMsg($totalmsg)
     {
         $this->setKey('X-SMS-Concatenate-Total-Messages', $totalmsg);
-
     }
+
     /**
      * Sets Account key.
      *

--- a/src/PAMI/Message/Message.php
+++ b/src/PAMI/Message/Message.php
@@ -108,7 +108,6 @@ abstract class Message
      */
     public function setVariable($key, $value)
     {
-        $key = strtolower($key);
         $this->variables[$key] = $value;
     }
 
@@ -121,7 +120,6 @@ abstract class Message
      */
     public function getVariable($key)
     {
-        $key = strtolower($key);
         if (!isset($this->variables[$key])) {
             return null;
         }


### PR DESCRIPTION
Starting from Asterisk 12, variables are case-sensitive.  
This PR remove case-insensitive variables allowing to set the right variable name in Asterisk >= 12.