### PR TITLE
EventMask parameter on login action

### DIFF
--- a/src/PAMI/Message/Action/LoginAction.php
+++ b/src/PAMI/Message/Action/LoginAction.php
@@ -46,15 +46,20 @@ class LoginAction extends ActionMessage
     /**
      * Constructor.
      *
-     * @param string $user     AMI username.
+     * @param string $user AMI username.
      * @param string $password AMI password.
+     * @param string|null $eventMask
      *
      * @return void
      */
-    public function __construct($user, $password)
+    public function __construct($user, $password, $eventMask = null)
     {
         parent::__construct('Login');
         $this->setKey('Username', $user);
         $this->setKey('Secret', $password);
+
+        if (null !== $eventMask) {
+            $this->setKey('Events', $eventMask);
+        }
     }
 }

--- a/test/actions/Test_Actions.php
+++ b/test/actions/Test_Actions.php
@@ -111,6 +111,37 @@ class Test_Actions extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function can_login()
+    {
+        $write = array(implode("\r\n", array(
+            'action: Login',
+            'actionid: 1432.123',
+            'username: foo',
+            'secret: bar',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\LoginAction('foo', 'bar');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_login_with_events()
+    {
+        $write = array(implode("\r\n", array(
+            'action: Login',
+            'actionid: 1432.123',
+            'username: foo',
+            'secret: bar',
+            'events: all',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\LoginAction('foo', 'bar', 'all');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
     public function can_agent_logoff()
     {
         $write = array(implode("\r\n", array(


### PR DESCRIPTION
This PR allows event parameter on login.
With this feature it's possible to disable events directly on LoginAction, with no overhead receiving events on connection and sending another command to disable them.