### PR TITLE
Fixed #57: Incorrect EOF test in getMessages

### DIFF
--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -130,7 +130,7 @@ class ClientImpl implements IClient
 
     /**
      * The receiving queue.
-     * @var IncomingMessage[]
+     * @var ResponseMessage[]
      */
     private $incomingQueue;
 
@@ -238,7 +238,7 @@ class ClientImpl implements IClient
         $msgs = array();
         // Read something.
         $read = @fread($this->socket, 65535);
-        if ($read === false || @feof($this->socket)) {
+        if ($read === false || (empty($read) && @feof($this->socket))) {
             throw new ClientException('Error reading');
         }
         $this->currentProcessingMessage .= $read;
@@ -372,12 +372,12 @@ class ClientImpl implements IClient
      *
      * @todo not suitable for multithreaded applications.
      *
-     * @return \PAMI\Message\IncomingMessage
+     * @return \PAMI\Message\Response\ResponseMessage
      */
     protected function getRelated(OutgoingMessage $message)
     {
         $ret = false;
-        $id = $message->getActionID('ActionID');
+        $id = $message->getActionID();
         if (isset($this->incomingQueue[$id])) {
             $response = $this->incomingQueue[$id];
             if ($response->isComplete()) {


### PR DESCRIPTION
It's possible to send a Logoff action. When this happens, Asterisk sends a response message and then close the connection. With this PR is possible to read the Logoff response message without throwing an exception if it's the last message and the connection is closed after that.

Also related to #121, because it's a good practice to send a logoff to disconnect, but sending it could throws an exception at this moment. This PR fix this.