### PR TITLE
Fix type in public method getUniqueid

### DIFF
--- a/src/PAMI/Message/Event/QueueCallerAbandonEvent.php
+++ b/src/PAMI/Message/Event/QueueCallerAbandonEvent.php
@@ -164,13 +164,13 @@ class QueueCallerAbandonEvent extends EventMessage
     }
 
     /**
-     * Returns key: 'Uniqueid'.
+     * Returns key: 'UniqueID'.
      *
      * @return string
      */
-    public function getUniqueid()
+    public function getUniqueID()
     {
-        return $this->getKey('Uniqueid');
+        return $this->getKey('UniqueID');
     }
 
     /**


### PR DESCRIPTION
Public method getUniqueid have suffix id in lowercase, but other events related to QueueCaller have suffix in uppercase. This quick patch fixes this.