### PR TITLE
Add BridgeInfo action and corresponding response events

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ can still catch them. If you catch one of these, please report it!
 * AGIExec
 * AsyncAGI
 * Bridge
+* BridgeInfoChannel
+* BridgeInfoComplete
 * CEL
 * ChannelUpdate
 * ConfbridgeStart
@@ -200,6 +202,7 @@ can still catch them. If you catch one of these, please report it!
 * AgentLogoff
 * Atxfer (asterisk 1.8?)
 * Bridge
+* BridgeInfo
 * ChangeMonitor
 * Command
 * ConfbridgeMute

--- a/doc/PAMI-Message-Action-BridgeInfoAction.md
+++ b/doc/PAMI-Message-Action-BridgeInfoAction.md
@@ -1,0 +1,310 @@
+PAMI\Message\Action\BridgeInfoAction
+===============
+
+Returns detailed information about a bridge and the channels in it.
+
+PHP Version 5
+
+
+* Class name: BridgeInfoAction
+* Namespace: PAMI\Message\Action
+* Parent class: [PAMI\Message\Action\ActionMessage](PAMI-Message-Action-ActionMessage.md)
+
+
+
+Constants
+----------
+
+
+### EOL
+
+    const EOL = "\r\n"
+
+
+
+
+
+### EOM
+
+    const EOM = "\r\n\r\n"
+
+
+
+
+
+Properties
+----------
+
+
+### $lines
+
+    protected array<mixed,string> $lines
+
+Message content, line by line. This is what it gets sent
+or received literally.
+
+
+
+* Visibility: **protected**
+
+
+### $variables
+
+    protected array<mixed,string> $variables
+
+Metadata. Message variables (key/value).
+
+
+
+* Visibility: **protected**
+
+
+### $keys
+
+    protected array<mixed,string> $keys
+
+Metadata. Message "keys" i.e: Action: login
+
+
+
+* Visibility: **protected**
+
+
+### $createdDate
+
+    protected integer $createdDate
+
+Created date (unix timestamp).
+
+
+
+* Visibility: **protected**
+
+
+Methods
+-------
+
+
+### __construct
+
+    void PAMI\Message\Message::__construct()
+
+Constructor.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### setActionID
+
+    void PAMI\Message\Action\ActionMessage::setActionID($actionID)
+
+Sets Action ID.
+
+The ActionID can be at most 69 characters long, according to
+[Asterisk Issue 14847](https://issues.asterisk.org/jira/browse/14847).
+
+Therefore we'll throw an exception when the ActionID is too long.
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Action\ActionMessage](PAMI-Message-Action-ActionMessage.md)
+
+
+#### Arguments
+* $actionID **mixed** - &lt;p&gt;The Action ID to have this action known by&lt;/p&gt;
+
+
+
+### __sleep
+
+    array<mixed,string> PAMI\Message\Message::__sleep()
+
+Serialize function.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getCreatedDate
+
+    integer PAMI\Message\Message::getCreatedDate()
+
+Returns created date.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### setVariable
+
+    void PAMI\Message\Message::setVariable(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+* $value **string** - &lt;p&gt;Variable value.&lt;/p&gt;
+
+
+
+### getVariable
+
+    string PAMI\Message\Message::getVariable(string $key)
+
+Returns a variable by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+
+
+
+### setKey
+
+    void PAMI\Message\Message::setKey(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+* $value **string** - &lt;p&gt;Key value.&lt;/p&gt;
+
+
+
+### getKey
+
+    string PAMI\Message\Message::getKey(string $key)
+
+Returns a key by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+
+
+
+### getKeys
+
+    array<mixed,string> PAMI\Message\Message::getKeys()
+
+Returns all keys for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getVariables
+
+    array<mixed,string> PAMI\Message\Message::getVariables()
+
+Returns all variabels for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### finishMessage
+
+    string PAMI\Message\Message::finishMessage($message)
+
+Returns the end of message token appended to the end of a given message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $message **mixed**
+
+
+
+### serializeVariable
+
+    string PAMI\Message\Message::serializeVariable(string $key, string $value)
+
+Returns the string representation for an ami action variable.
+
+
+
+* Visibility: **private**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string**
+* $value **string**
+
+
+
+### serialize
+
+    string PAMI\Message\Message::serialize()
+
+Gives a string representation for this message, ready to be sent to
+ami.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getActionID
+
+    string PAMI\Message\Message::getActionID()
+
+Returns key: 'ActionID'.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+

--- a/doc/PAMI-Message-Event-BridgeInfoChannelEvent.md
+++ b/doc/PAMI-Message-Event-BridgeInfoChannelEvent.md
@@ -1,0 +1,558 @@
+PAMI\Message\Event\BridgeInfoChannelEvent
+===============
+
+Event triggered when an action BridgeInfo is issued.
+
+PHP Version 5
+
+
+* Class name: BridgeInfoChannelEvent
+* Namespace: PAMI\Message\Event
+* Parent class: [PAMI\Message\Event\EventMessage](PAMI-Message-Event-EventMessage.md)
+
+
+
+Constants
+----------
+
+
+### EOL
+
+    const EOL = "\r\n"
+
+
+
+
+
+### EOM
+
+    const EOM = "\r\n\r\n"
+
+
+
+
+
+Properties
+----------
+
+
+### $rawContent
+
+    protected string $rawContent
+
+Holds original message.
+
+
+
+* Visibility: **protected**
+
+
+### $channelVariables
+
+    protected array<mixed,string> $channelVariables
+
+Metadata. Specific channel variables.
+
+
+
+* Visibility: **protected**
+
+
+### $lines
+
+    protected array<mixed,string> $lines
+
+Message content, line by line. This is what it gets sent
+or received literally.
+
+
+
+* Visibility: **protected**
+
+
+### $variables
+
+    protected array<mixed,string> $variables
+
+Metadata. Message variables (key/value).
+
+
+
+* Visibility: **protected**
+
+
+### $keys
+
+    protected array<mixed,string> $keys
+
+Metadata. Message "keys" i.e: Action: login
+
+
+
+* Visibility: **protected**
+
+
+### $createdDate
+
+    protected integer $createdDate
+
+Created date (unix timestamp).
+
+
+
+* Visibility: **protected**
+
+
+Methods
+-------
+
+
+### getChannel
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getChannel()
+
+Returns key: 'Channel'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getChannelState
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getChannelState()
+
+Returns key: 'ChannelState'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getChannelStateDesc
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getChannelStateDesc()
+
+Returns key: 'ChannelStateDesc'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getCallerIDNum
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getCallerIDNum()
+
+Returns key: 'CallerIDNum'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getCallerIDName
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getCallerIDName()
+
+Returns key: 'CallerIDName'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getConnectedLineNum
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getConnectedLineNum()
+
+Returns key: 'ConnectedLineNum'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getConnectedLineName
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getConnectedLineName()
+
+Returns key: 'ConnectedLineName'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getAccountCode
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getAccountCode()
+
+Returns key: 'AccountCode'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getContext
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getContext()
+
+Returns key: 'Context'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getExten
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getExten()
+
+Returns key: 'Exten'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getPriority
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getPriority()
+
+Returns key: 'Priority'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getUniqueid
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getUniqueid()
+
+Returns key: 'Uniqueid'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getLinkedid
+
+    string PAMI\Message\Event\BridgeInfoChannelEvent::getLinkedid()
+
+Returns key: 'Linkedid'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getName
+
+    string PAMI\Message\Event\EventMessage::getName()
+
+Returns key 'Event'.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Event\EventMessage](PAMI-Message-Event-EventMessage.md)
+
+
+
+
+### __sleep
+
+    array<mixed,string> PAMI\Message\Message::__sleep()
+
+Serialize function.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getEventList
+
+    string PAMI\Message\IncomingMessage::getEventList()
+
+Returns key 'EventList'. In respones, this will surely be a "start". In
+events, should be a "complete".
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getRawContent
+
+    string PAMI\Message\IncomingMessage::getRawContent()
+
+Returns the original message content without parsing.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getAllChannelVariables
+
+    array PAMI\Message\IncomingMessage::getAllChannelVariables()
+
+Returns the channel variables for all reported channels.
+
+https://github.com/marcelog/PAMI/issues/85
+
+The channel names will be lowercased.
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getChannelVariables
+
+    array PAMI\Message\IncomingMessage::getChannelVariables(string $channel)
+
+Returns the channel variables for the given channel.
+
+https://github.com/marcelog/PAMI/issues/85
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+#### Arguments
+* $channel **string** - &lt;p&gt;Channel name. If not given, will return variables
+for the &quot;current&quot; channel.&lt;/p&gt;
+
+
+
+### __construct
+
+    void PAMI\Message\Message::__construct()
+
+Constructor.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getCreatedDate
+
+    integer PAMI\Message\Message::getCreatedDate()
+
+Returns created date.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### setVariable
+
+    void PAMI\Message\Message::setVariable(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+* $value **string** - &lt;p&gt;Variable value.&lt;/p&gt;
+
+
+
+### getVariable
+
+    string PAMI\Message\Message::getVariable(string $key)
+
+Returns a variable by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+
+
+
+### setKey
+
+    void PAMI\Message\Message::setKey(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+* $value **string** - &lt;p&gt;Key value.&lt;/p&gt;
+
+
+
+### getKey
+
+    string PAMI\Message\Message::getKey(string $key)
+
+Returns a key by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+
+
+
+### getKeys
+
+    array<mixed,string> PAMI\Message\Message::getKeys()
+
+Returns all keys for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getVariables
+
+    array<mixed,string> PAMI\Message\Message::getVariables()
+
+Returns all variabels for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### finishMessage
+
+    string PAMI\Message\Message::finishMessage($message)
+
+Returns the end of message token appended to the end of a given message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $message **mixed**
+
+
+
+### serializeVariable
+
+    string PAMI\Message\Message::serializeVariable(string $key, string $value)
+
+Returns the string representation for an ami action variable.
+
+
+
+* Visibility: **private**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string**
+* $value **string**
+
+
+
+### serialize
+
+    string PAMI\Message\Message::serialize()
+
+Gives a string representation for this message, ready to be sent to
+ami.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getActionID
+
+    string PAMI\Message\Message::getActionID()
+
+Returns key: 'ActionID'.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+

--- a/doc/PAMI-Message-Event-BridgeInfoCompleteEvent.md
+++ b/doc/PAMI-Message-Event-BridgeInfoCompleteEvent.md
@@ -1,0 +1,493 @@
+PAMI\Message\Event\BridgeInfoCompleteEvent
+===============
+
+Event triggered for the end of the list when an action BridgeInfo is issued.
+
+PHP Version 5
+
+
+* Class name: BridgeInfoCompleteEvent
+* Namespace: PAMI\Message\Event
+* Parent class: [PAMI\Message\Event\EventMessage](PAMI-Message-Event-EventMessage.md)
+
+
+
+Constants
+----------
+
+
+### EOL
+
+    const EOL = "\r\n"
+
+
+
+
+
+### EOM
+
+    const EOM = "\r\n\r\n"
+
+
+
+
+
+Properties
+----------
+
+
+### $rawContent
+
+    protected string $rawContent
+
+Holds original message.
+
+
+
+* Visibility: **protected**
+
+
+### $channelVariables
+
+    protected array<mixed,string> $channelVariables
+
+Metadata. Specific channel variables.
+
+
+
+* Visibility: **protected**
+
+
+### $lines
+
+    protected array<mixed,string> $lines
+
+Message content, line by line. This is what it gets sent
+or received literally.
+
+
+
+* Visibility: **protected**
+
+
+### $variables
+
+    protected array<mixed,string> $variables
+
+Metadata. Message variables (key/value).
+
+
+
+* Visibility: **protected**
+
+
+### $keys
+
+    protected array<mixed,string> $keys
+
+Metadata. Message "keys" i.e: Action: login
+
+
+
+* Visibility: **protected**
+
+
+### $createdDate
+
+    protected integer $createdDate
+
+Created date (unix timestamp).
+
+
+
+* Visibility: **protected**
+
+
+Methods
+-------
+
+
+### getBridgeUniqueid
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeUniqueid()
+
+Returns key: 'BridgeUniqueid'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeType
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeType()
+
+Returns key: 'BridgeType'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeTechnology
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeTechnology()
+
+Returns key: 'BridgeTechnology'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeCreator
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeCreator()
+
+Returns key: 'BridgeCreator'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeName
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeName()
+
+Returns key: 'BridgeName'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeNumChannels
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeNumChannels()
+
+Returns key: 'BridgeNumChannels'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeVideoSourceMode
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeVideoSourceMode()
+
+Returns key: 'BridgeVideoSourceMode'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getBridgeVideoSource
+
+    string PAMI\Message\Event\BridgeInfoCompleteEvent::getBridgeVideoSource()
+
+Returns key: 'BridgeVideoSource'.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getName
+
+    string PAMI\Message\Event\EventMessage::getName()
+
+Returns key 'Event'.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Event\EventMessage](PAMI-Message-Event-EventMessage.md)
+
+
+
+
+### __sleep
+
+    array<mixed,string> PAMI\Message\Message::__sleep()
+
+Serialize function.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getEventList
+
+    string PAMI\Message\IncomingMessage::getEventList()
+
+Returns key 'EventList'. In respones, this will surely be a "start". In
+events, should be a "complete".
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getRawContent
+
+    string PAMI\Message\IncomingMessage::getRawContent()
+
+Returns the original message content without parsing.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getAllChannelVariables
+
+    array PAMI\Message\IncomingMessage::getAllChannelVariables()
+
+Returns the channel variables for all reported channels.
+
+https://github.com/marcelog/PAMI/issues/85
+
+The channel names will be lowercased.
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+
+
+### getChannelVariables
+
+    array PAMI\Message\IncomingMessage::getChannelVariables(string $channel)
+
+Returns the channel variables for the given channel.
+
+https://github.com/marcelog/PAMI/issues/85
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\IncomingMessage](PAMI-Message-IncomingMessage.md)
+
+
+#### Arguments
+* $channel **string** - &lt;p&gt;Channel name. If not given, will return variables
+for the &quot;current&quot; channel.&lt;/p&gt;
+
+
+
+### __construct
+
+    void PAMI\Message\Message::__construct()
+
+Constructor.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getCreatedDate
+
+    integer PAMI\Message\Message::getCreatedDate()
+
+Returns created date.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### setVariable
+
+    void PAMI\Message\Message::setVariable(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+* $value **string** - &lt;p&gt;Variable value.&lt;/p&gt;
+
+
+
+### getVariable
+
+    string PAMI\Message\Message::getVariable(string $key)
+
+Returns a variable by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Variable name.&lt;/p&gt;
+
+
+
+### setKey
+
+    void PAMI\Message\Message::setKey(string $key, string $value)
+
+Adds a variable to this message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+* $value **string** - &lt;p&gt;Key value.&lt;/p&gt;
+
+
+
+### getKey
+
+    string PAMI\Message\Message::getKey(string $key)
+
+Returns a key by name.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string** - &lt;p&gt;Key name (i.e: Action).&lt;/p&gt;
+
+
+
+### getKeys
+
+    array<mixed,string> PAMI\Message\Message::getKeys()
+
+Returns all keys for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getVariables
+
+    array<mixed,string> PAMI\Message\Message::getVariables()
+
+Returns all variabels for this message.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### finishMessage
+
+    string PAMI\Message\Message::finishMessage($message)
+
+Returns the end of message token appended to the end of a given message.
+
+
+
+* Visibility: **protected**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $message **mixed**
+
+
+
+### serializeVariable
+
+    string PAMI\Message\Message::serializeVariable(string $key, string $value)
+
+Returns the string representation for an ami action variable.
+
+
+
+* Visibility: **private**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+#### Arguments
+* $key **string**
+* $value **string**
+
+
+
+### serialize
+
+    string PAMI\Message\Message::serialize()
+
+Gives a string representation for this message, ready to be sent to
+ami.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+
+
+### getActionID
+
+    string PAMI\Message\Message::getActionID()
+
+Returns key: 'ActionID'.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAMI\Message\Message](PAMI-Message-Message.md)
+
+
+

--- a/src/PAMI/Message/Action/BridgeInfoAction.php
+++ b/src/PAMI/Message/Action/BridgeInfoAction.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Returns detailed information about a bridge and the channels in it.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * Returns detailed information about a bridge and the channels in it.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class BridgeInfoAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $bridgeUniqueid The unique ID of the bridge about which to retrieve information.
+     *
+     * @return void
+     */
+    public function __construct($bridgeUniqueid)
+    {
+        parent::__construct('BridgeInfo');
+
+        $this->setKey('BridgeUniqueid', $bridgeUniqueid);
+    }
+}

--- a/src/PAMI/Message/Event/BridgeInfoChannelEvent.php
+++ b/src/PAMI/Message/Event/BridgeInfoChannelEvent.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Event triggered when an action BridgeInfo is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+/**
+ * Event triggered when an action BridgeInfo is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class BridgeInfoChannelEvent extends EventMessage
+{
+    /**
+     * Returns key: 'Channel'.
+     *
+     * @return string
+     */
+    public function getChannel()
+    {
+        return $this->getKey('Channel');
+    }
+
+    /**
+     * Returns key: 'ChannelState'.
+     *
+     * @return string
+     */
+    public function getChannelState()
+    {
+        return $this->getKey('ChannelState');
+    }
+
+    /**
+     * Returns key: 'ChannelStateDesc'.
+     *
+     * @return string
+     */
+    public function getChannelStateDesc()
+    {
+        return $this->getKey('ChannelStateDesc');
+    }
+
+    /**
+     * Returns key: 'CallerIDNum'.
+     *
+     * @return string
+     */
+    public function getCallerIDNum()
+    {
+        return $this->getKey('CallerIDNum');
+    }
+
+    /**
+     * Returns key: 'CallerIDName'.
+     *
+     * @return string
+     */
+    public function getCallerIDName()
+    {
+        return $this->getKey('CallerIDName');
+    }
+
+    /**
+     * Returns key: 'ConnectedLineNum'.
+     *
+     * @return string
+     */
+    public function getConnectedLineNum()
+    {
+        return $this->getKey('ConnectedLineNum');
+    }
+
+    /**
+     * Returns key: 'ConnectedLineName'.
+     *
+     * @return string
+     */
+    public function getConnectedLineName()
+    {
+        return $this->getKey('ConnectedLineName');
+    }
+
+    /**
+     * Returns key: 'AccountCode'.
+     *
+     * @return string
+     */
+    public function getAccountCode()
+    {
+        return $this->getKey('AccountCode');
+    }
+
+    /**
+     * Returns key: 'Context'.
+     *
+     * @return string
+     */
+    public function getContext()
+    {
+        return $this->getKey('Context');
+    }
+
+    /**
+     * Returns key: 'Exten'.
+     *
+     * @return string
+     */
+    public function getExten()
+    {
+        return $this->getKey('Exten');
+    }
+
+    /**
+     * Returns key: 'Priority'.
+     *
+     * @return string
+     */
+    public function getPriority()
+    {
+        return $this->getKey('Priority');
+    }
+
+    /**
+     * Returns key: 'Uniqueid'.
+     *
+     * @return string
+     */
+    public function getUniqueid()
+    {
+        return $this->getKey('Uniqueid');
+    }
+
+    /**
+     * Returns key: 'Linkedid'.
+     *
+     * @return string
+     */
+    public function getLinkedid()
+    {
+        return $this->getKey('Linkedid');
+    }
+}

--- a/src/PAMI/Message/Event/BridgeInfoCompleteEvent.php
+++ b/src/PAMI/Message/Event/BridgeInfoCompleteEvent.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Event triggered for the end of the list when an action BridgeInfo is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+/**
+ * Event triggered for the end of the list when an action BridgeInfo is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class BridgeInfoCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'BridgeUniqueid'.
+     *
+     * @return string
+     */
+    public function getBridgeUniqueid()
+    {
+        return $this->getKey('BridgeUniqueid');
+    }
+
+    /**
+     * Returns key: 'BridgeType'.
+     *
+     * @return string
+     */
+    public function getBridgeType()
+    {
+        return $this->getKey('BridgeType');
+    }
+
+    /**
+     * Returns key: 'BridgeTechnology'.
+     *
+     * @return string
+     */
+    public function getBridgeTechnology()
+    {
+        return $this->getKey('BridgeTechnology');
+    }
+
+    /**
+     * Returns key: 'BridgeCreator'.
+     *
+     * @return string
+     */
+    public function getBridgeCreator()
+    {
+        return $this->getKey('BridgeCreator');
+    }
+
+    /**
+     * Returns key: 'BridgeName'.
+     *
+     * @return string
+     */
+    public function getBridgeName()
+    {
+        return $this->getKey('BridgeName');
+    }
+
+    /**
+     * Returns key: 'BridgeNumChannels'.
+     *
+     * @return string
+     */
+    public function getBridgeNumChannels()
+    {
+        return $this->getKey('BridgeNumChannels');
+    }
+
+    /**
+     * Returns key: 'BridgeVideoSourceMode'.
+     *
+     * @return string
+     */
+    public function getBridgeVideoSourceMode()
+    {
+        return $this->getKey('BridgeVideoSourceMode');
+    }
+
+    /**
+     * Returns key: 'BridgeVideoSource'.
+     *
+     * @return string
+     */
+    public function getBridgeVideoSource()
+    {
+        return $this->getKey('BridgeVideoSource');
+    }
+}

--- a/test/actions/Test_Actions.php
+++ b/test/actions/Test_Actions.php
@@ -219,6 +219,22 @@ class Test_Actions extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function can_bridge_info()
+    {
+        $bridge_uniqueid = '57cb3a7e-0fa3-4e28-924f-d7728b0d7a9a';
+
+        $write = array(implode("\r\n", array(
+            'action: BridgeInfo',
+            'actionid: 1432.123',
+            'bridgeuniqueid: '. $bridge_uniqueid,
+            ''
+        )));
+        $action = new \PAMI\Message\Action\BridgeInfoAction($bridge_uniqueid);
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
     public function can_challenge()
     {
         $write = array(implode("\r\n", array(

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -99,6 +99,8 @@ class Test_Events extends \PHPUnit_Framework_TestCase
             'ConfbridgeMute',
             'ConfbridgeUnmute',
             'ConfbridgeTalking',
+            'BridgeInfoChannel',
+            'BridgeInfoComplete',
         );
         $eventTranslatedValues = array(
             'QueueMemberStatus' => array(
@@ -1392,6 +1394,31 @@ class Test_Events extends \PHPUnit_Framework_TestCase
                 'Linkedid' => 'Linkedid',
                 'TalkingStatus' => 'TalkingStatus',
                 'Admin' => 'Admin',
+            ),
+            'BridgeInfoChannel' => array(
+                'Channel' => 'Channel',
+                'ChannelState' => 'ChannelState',
+                'ChannelStateDesc' => 'ChannelStateDesc',
+                'CallerIDNum' => 'CallerIDNum',
+                'CallerIDName' => 'CallerIDName',
+                'ConnectedLineNum' => 'ConnectedLineNum',
+                'ConnectedLineName' => 'ConnectedLineName',
+                'AccountCode' => 'AccountCode',
+                'Context' => 'Context',
+                'Exten' => 'Exten',
+                'Priority' => 'Priority',
+                'Uniqueid' => 'Uniqueid',
+                'Linkedid' => 'Linkedid',
+            ),
+            'BridgeInfoComplete' => array(
+                'BridgeUniqueid' => 'BridgeUniqueid',
+                'BridgeType' => 'BridgeType',
+                'BridgeTechnology' => 'BridgeTechnology',
+                'BridgeCreator' => 'BridgeCreator',
+                'BridgeName' => 'BridgeName',
+                'BridgeNumChannels' => 'BridgeNumChannels',
+                'BridgeVideoSourceMode' => 'BridgeVideoSourceMode',
+                'BridgeVideoSource' => 'BridgeVideoSource',
             ),
         );
         $eventGetters = array(


### PR DESCRIPTION
Asterisk 12 introduced the BridgeInfo AMI action for getting detailed
information about a bridge and the channels in it. When the action is
issued, Asterisk responds with a list of BridgeInfoChannel events
terminated by a BridgeInfoComplete event.

Resolves #144