### PR TITLE
Allow self-signed certificates in PHP 5.6+

### DIFF
--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -163,7 +163,12 @@ class ClientImpl implements IClient
     public function open()
     {
         $cString = $this->scheme . $this->host . ':' . $this->port;
-        $this->context = stream_context_create();
+        $this->context = stream_context_create([
+            'ssl' => [
+                'verify_peer'       => false,
+                'verify_peer_name'  => false
+            ]
+        ]);
         $errno = 0;
         $errstr = '';
         $this->socket = @stream_socket_client(


### PR DESCRIPTION
Changes made to openssl in php 5.6+ modified default behavior for self-signed certificates.

http://php.net/manual/en/migration56.openssl.php