### PR TITLE
Add `getSocket()` method to `ClientImpl` class

### DIFF
--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -446,6 +446,16 @@ class ClientImpl implements IClient
     {
         $this->logger = $logger;
     }
+    
+    /**
+     * Returns stream socket.
+     *
+     * @return resource
+     */
+    public function getSocket() 
+    {
+        return $this->socket;
+    }
 
     /**
      * Constructor.

--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -452,7 +452,7 @@ class ClientImpl implements IClient
      *
      * @return resource
      */
-    public function getSocket() 
+    public function getSocket()
     {
         return $this->socket;
     }


### PR DESCRIPTION
Getting the underlying socket might be necessary when PAMI is used as a part of a larger program. 

For example, incorporating PAMI in ReactPHP EventLoop:
```
$loop = Factory::create();
$loop->addReadStream($PAMIClient->getSocket(), function($stream) use($PAMIClient) {
    $PAMIClient->process();
});

// ...

$loop->run();
```