### PR TITLE
Add some new actions and corresponding events about ConfBridge

### DIFF
--- a/src/PAMI/Message/Action/ConfbridgeKickAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeKickAction.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * ConfbridgeKick action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeKick action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeKickAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $channel Channel to be muted.
+     * @param string $conference Conference on which to act.
+     *
+     * @return void
+     */
+    public function __construct($channel, $conference)
+    {
+        parent::__construct('ConfbridgeKick');
+        $this->setKey('Channel', $channel);
+        $this->setKey('Conference', $conference);
+    }
+}

--- a/src/PAMI/Message/Action/ConfbridgeListRoomsAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeListRoomsAction.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ConfbridgeListRooms action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeListRooms action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeListRoomsAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct('ConfbridgeListRooms');
+    }
+}

--- a/src/PAMI/Message/Action/ConfbridgeLockAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeLockAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ConfbridgeLock action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeLock action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeLockAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $conference Conference on which to act.
+     *
+     * @return void
+     */
+    public function __construct($conference)
+    {
+        parent::__construct('ConfbridgeLock');
+        $this->setKey('Conference', $conference);
+    }
+}

--- a/src/PAMI/Message/Action/ConfbridgeStartRecordAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeStartRecordAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ConfbridgeStartRecord action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeStartRecord action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeStartRecordAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $conference Conference on which to act.
+     *
+     * @return void
+     */
+    public function __construct($conference)
+    {
+        parent::__construct('ConfbridgeStartRecord');
+        $this->setKey('Conference', $conference);
+    }
+}

--- a/src/PAMI/Message/Action/ConfbridgeStopRecordAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeStopRecordAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ConfbridgeStopRecord action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeStopRecord action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeStopRecordAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $conference Conference on which to act.
+     *
+     * @return void
+     */
+    public function __construct($conference)
+    {
+        parent::__construct('ConfbridgeStopRecord');
+        $this->setKey('Conference', $conference);
+    }
+}

--- a/src/PAMI/Message/Action/ConfbridgeUnlockAction.php
+++ b/src/PAMI/Message/Action/ConfbridgeUnlockAction.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * ConfbridgeUnlock action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Action;
+
+/**
+ * ConfbridgeUnlock action message.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Action
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeUnlockAction extends ActionMessage
+{
+    /**
+     * Constructor.
+     *
+     * @param string $conference Conference on which to act.
+     *
+     * @return void
+     */
+    public function __construct($conference)
+    {
+        parent::__construct('ConfbridgeUnlock');
+        $this->setKey('Conference', $conference);
+    }
+}

--- a/src/PAMI/Message/Event/ConfbridgeListRoomsCompleteEvent.php
+++ b/src/PAMI/Message/Event/ConfbridgeListRoomsCompleteEvent.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Event triggered for the end of the list when an action ConfbridgeListRooms is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered for the end of the list when an action ConfbridgeListRooms is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Matt Styles <mstyleshk@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeListRoomsCompleteEvent extends EventMessage
+{
+    /**
+     * Returns key: 'ListItems'.
+     *
+     * @return string
+     */
+    public function getListItems()
+    {
+        return $this->getKey('ListItems');
+    }
+}

--- a/src/PAMI/Message/Event/ConfbridgeListRoomsEvent.php
+++ b/src/PAMI/Message/Event/ConfbridgeListRoomsEvent.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Event triggered for each conference when an action ConfbridgeListRooms is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @version    SVN: $Id$
+ * @link       http://marcelog.github.com/PAMI/
+ *
+ * Copyright 2011 Marcelo Gornstein <marcelog@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+namespace PAMI\Message\Event;
+
+use PAMI\Message\Event\EventMessage;
+
+/**
+ * Event triggered for each conference when an action ConfbridgeListRooms is issued.
+ *
+ * PHP Version 5
+ *
+ * @category   Pami
+ * @package    Message
+ * @subpackage Event
+ * @author     Marcelo Gornstein <marcelog@gmail.com>
+ * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
+ * @link       http://marcelog.github.com/PAMI/
+ */
+class ConfbridgeListRoomsEvent extends EventMessage
+{
+    /**
+     * Returns key: 'Conference'.
+     *
+     * @return string
+     */
+    public function getConference()
+    {
+        return $this->getKey('Conference');
+    }
+
+    /**
+     * Returns key: 'Parties'.
+     *
+     * @return string
+     */
+    public function getParties()
+    {
+        return $this->getKey('Parties');
+    }
+
+    /**
+     * Returns key: 'Marked'.
+     *
+     * @return string
+     */
+    public function getMaked()
+    {
+        return $this->getKey('Marked');
+    }
+
+    /**
+     * Returns key: 'Locked'.
+     *
+     * @return string
+     */
+    public function getLocked()
+    {
+        return $this->getKey('Locked');
+    }
+}

--- a/test/actions/Test_Actions.php
+++ b/test/actions/Test_Actions.php
@@ -278,6 +278,20 @@ class Test_Actions extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function can_confbridge_list_rooms()
+    {
+        $conference = 'conf-59dba3997444e5';
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeListRooms',
+            'actionid: 1432.123',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeListRoomsAction();
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
     public function can_confbridge_list()
     {
         $conference = 'conf-59dba3997444e5';
@@ -318,6 +332,77 @@ class Test_Actions extends \PHPUnit_Framework_TestCase
             ''
         )));
         $action = new \PAMI\Message\Action\ConfbridgeUnmuteAction('channel', 'conference');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_confbridge_lock()
+    {
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeLock',
+            'actionid: 1432.123',
+            'conference: conference',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeLockAction('conference');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_confbridge_unlock()
+    {
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeUnlock',
+            'actionid: 1432.123',
+            'conference: conference',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeUnlockAction('conference');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_confbridge_kick()
+    {
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeKick',
+            'actionid: 1432.123',
+            'channel: channel',
+            'conference: conference',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeKickAction('channel', 'conference');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_confbridge_start_record()
+    {
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeStartRecord',
+            'actionid: 1432.123',
+            'conference: conference',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeStartRecordAction('conference');
+        $client = $this->_start($write, $action);
+    }
+    /**
+     * @test
+     */
+    public function can_confbridge_stop_record()
+    {
+        $write = array(implode("\r\n", array(
+            'action: ConfbridgeStopRecord',
+            'actionid: 1432.123',
+            'conference: conference',
+            ''
+        )));
+        $action = new \PAMI\Message\Action\ConfbridgeStopRecordAction('conference');
         $client = $this->_start($write, $action);
     }
     /**

--- a/test/events/Test_Events.php
+++ b/test/events/Test_Events.php
@@ -1411,6 +1411,13 @@ class Test_Events extends \PHPUnit_Framework_TestCase
                 'Admin' => 'Admin',
             ),
             'ConfbridgeListComplete' => array('ListItems' => 'ListItems'),
+            'ConfbridgeListRooms' => array(
+                'Conference' => 'Conference',
+                'Parties' => 'Parties',
+                'Marked' => 'Marked',
+                'Locked' => 'Locked',
+            ),
+            'ConfbridgeListRoomsComplete' => array('ListItems' => 'ListItems'),
             'BridgeInfoChannel' => array(
                 'Channel' => 'Channel',
                 'ChannelState' => 'ChannelState',


### PR DESCRIPTION
Hi,

I implement some new actions and corresponding events about _ConfBridge_ :

- _ConfbridgeListRooms_ action and it's _ConfbridgeListRooms_ and _ConfbridgeListRoomsComplete_ events
- _ConfbridgeLock_ and _ConfbridgeUnlock_ actions (no corresponding event)
- _ConfbridgeKick_ action (no corresponding event)
- _ConfbridgeStartRecord_ and _ConfbridgeStopRecord_ actions (no corresponding event)

This _PR_ include tests as implemented for other similar actions/events.

Thank you,