### PR TITLE
Fixed handling of broken events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.lock
 vendor
+.idea
 .buildpath
 .project
 .settings

--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -289,7 +289,10 @@ class ClientImpl implements IClient
                 $bMsg .= 'ActionId: ' . $this->lastActionId . "\r\n" . $aMsg;
                 $event = $this->messageToEvent($bMsg);
                 $response = $this->findResponse($event);
-                $response->addEvent($event);
+
+                if ($response instanceof ResponseMessage) {
+                    $response->addEvent($event);
+                }
             }
             $this->logger->debug('----------------');
         }


### PR DESCRIPTION
As `$this->findResponse($event)` can return `false` sometimes you get `Call to a member function addEvent() on bool` error