### PR TITLE
fix PHP7.4 compatibility variable order on implode()

### DIFF
--- a/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -69,7 +69,7 @@ class EventFactoryImpl
         for ($i = 0; $i < $totalParts; $i++) {
             $parts[$i] = ucfirst($parts[$i]);
         }
-        $name = implode($parts, '');
+        $name = implode('', $parts);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
         if (class_exists($className, true)) {
             return new $className($message);


### PR DESCRIPTION
causes error with PHP7.4  (v7.4.3 in my case)
`ErrorException: implode(): Passing glue string after array is deprecated. Swap the parameters in ../marcelog/pami/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php:72`
No issue in the rest of the code, this seemed the lonely leftover.