### PR TITLE
ListDialplanEvent psr-4 comply

### DIFF
--- a/src/PAMI/Message/Event/ListDialplanEvent.php
+++ b/src/PAMI/Message/Event/ListDialplanEvent.php
@@ -43,7 +43,7 @@ use PAMI\Message\Event\EventMessage;
  * @license    http://marcelog.github.com/PAMI/ Apache License 2.0
  * @link       http://marcelog.github.com/PAMI/
  */
-class ListDialPlanEvent extends EventMessage
+class ListDialplanEvent extends EventMessage
 {
     /**
      * Returns key: 'Context'.


### PR DESCRIPTION
Fix Deprecation Notice: Class PAMI\Message\Event\ListDialPlanEvent located in vendor/marcelog/pami/src/PAMI\Message\Event\ListDialplanEvent.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0.