### PR TITLE
Implode PHP 7.4 with back compatibility

### DIFF
--- a/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -69,7 +69,7 @@ class EventFactoryImpl
         for ($i = 0; $i < $totalParts; $i++) {
             $parts[$i] = ucfirst($parts[$i]);
         }
-        if (PHP_MAJOR_VERSION < 7 || PHP_MINOR_VERSION < 4) {
+        if (PHP_MAJOR_VERSION < 7 || (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 4)) {
             $name = implode($parts, '');
         } else {
             $name = implode('', $parts);

--- a/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -69,7 +69,11 @@ class EventFactoryImpl
         for ($i = 0; $i < $totalParts; $i++) {
             $parts[$i] = ucfirst($parts[$i]);
         }
-        $name = implode('', $parts);
+        if (PHP_MAJOR_VERSION < 7 || PHP_MINOR_VERSION < 4) {
+            $name = implode($parts, '');
+        } else {
+            $name = implode('', $parts);
+        }
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
         if (class_exists($className, true)) {
             return new $className($message);


### PR DESCRIPTION
We have live servers running on PHP 7.3 and dev servers running 7.4 and +
This should fix the issue for any version.