### PR TITLE
PHP8.1 : stristr(): Passing null to parameter

### DIFF
--- a/src/PAMI/Message/Response/ResponseMessage.php
+++ b/src/PAMI/Message/Response/ResponseMessage.php
@@ -131,10 +131,7 @@ class ResponseMessage extends IncomingMessage
      */
     public function isList()
     {
-        return
-            stristr($this->getKey('EventList'), 'start') !== false
-            || stristr($this->getMessage(), 'follow') !== false
-        ;
+        return ($this->getKey('EventList') && stristr($this->getKey('EventList'), 'start') !== false) || ($this->getMessage() && stristr($this->getMessage(), 'follow') !== false);
     }
 
     /**


### PR DESCRIPTION
stristr(): Passing null to parameter failed on PHP8.1