### PR TITLE
Normalize implode() argument order for code PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "SaidNizamWevetel/pami",
+  "name": "said-nizam-wevetel/pami",
   "type": "library",
   "description": "Asterisk Manager Interface (AMI) client for PHP, event driven, object oriented",
   "keywords": ["asterisk","ami","client","telephony","voip","event","action","manager","monitor"],

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-  "name": "marcelog/pami",
+  "name": "SaidNizamWevetel/pami",
   "type": "library",
   "description": "Asterisk Manager Interface (AMI) client for PHP, event driven, object oriented",
   "keywords": ["asterisk","ami","client","telephony","voip","event","action","manager","monitor"],
-  "homepage": "http://marcelog.github.com/PAMI",
+  "homepage": "https://github.com/SaidNizamWevetel/PAMI",
   "license": "Apache-2.0",
   "authors": [
     {
-      "name": "Marcelo Gornstein",
-      "email": "marcelog@gmail.com",
-      "homepage": "http://marcelog.github.com/",
+      "name": "Nizamuddin Nadim",
+      "email": "said.nizam@wevetel.com",
+      "homepage": "https://github.com/SaidNizamWevetel/PAMI",
       "role": "Developer"
     }
   ],

--- a/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -69,7 +69,7 @@ class EventFactoryImpl
         for ($i = 0; $i < $totalParts; $i++) {
             $parts[$i] = ucfirst($parts[$i]);
         }
-        $name = implode('', $parts);
+        $name = implode($parts, '');
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
         if (class_exists($className, true)) {
             return new $className($message);


### PR DESCRIPTION
This PR updates the implode() call to use the conventional argument order (array, separator) as recommended by the PHP manual.

What was changed

Updated:
$name = implode('', $parts);
to
$name = implode($parts, '');

Why
Both argument orders are accepted by PHP, but the canonical form is implode(array $pieces, string $separator).
Improves consistency with common PHP coding standards.
Makes the code clearer for developers who expect the standard ordering.

Impact
No functional change.
Purely a code-quality improvement.